### PR TITLE
fix: 本番環境のDB接続とOAuthリダイレクトを修正

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,7 +2,19 @@ import { defineConfig } from "drizzle-kit";
 import { isProductionLike, loadAppEnvFile } from "./scripts/lib/app-env.js";
 
 loadAppEnvFile();
-const databaseUrl = process.env.DATABASE_URL;
+const databaseUrl = process.env.DATABASE_URL?.trim();
+
+if (databaseUrl) {
+  const parsed = new URL(databaseUrl);
+  const hasHost = parsed.hostname.length > 0;
+  const hasSocketHost = parsed.searchParams.has("host");
+
+  if (!hasHost && !hasSocketHost) {
+    throw new Error(
+      "Invalid DATABASE_URL: DATABASE_URL must include a hostname or host query parameter.",
+    );
+  }
+}
 
 if (isProductionLike() && !databaseUrl) {
   throw new Error("DATABASE_URL is required for production drizzle commands.");

--- a/scripts/lib/database.ts
+++ b/scripts/lib/database.ts
@@ -9,7 +9,29 @@ loadAppEnvFile();
 
 export function getDatabaseUrl() {
 	if (process.env.DATABASE_URL) {
-		return process.env.DATABASE_URL;
+		const databaseUrl = process.env.DATABASE_URL.trim();
+
+		if (databaseUrl.length === 0) {
+			throw new Error("DATABASE_URL must not be empty.");
+		}
+
+		try {
+			const parsed = new URL(databaseUrl);
+			const hasHost = parsed.hostname.length > 0;
+			const hasSocketHost = parsed.searchParams.has("host");
+
+			if (!hasHost && !hasSocketHost) {
+				throw new Error(
+					"DATABASE_URL must include a hostname or host query parameter."
+				);
+			}
+
+			return databaseUrl;
+		} catch (error) {
+			throw new Error(
+				`Invalid DATABASE_URL: ${error instanceof Error ? error.message : "failed to parse database url."}`
+			);
+		}
 	}
 
 	if (isProductionLike()) {

--- a/scripts/run-drizzle.mjs
+++ b/scripts/run-drizzle.mjs
@@ -9,7 +9,20 @@ if (args.length === 0) {
 }
 
 loadAppEnvFile();
-const databaseUrl = process.env.DATABASE_URL;
+const databaseUrl = process.env.DATABASE_URL?.trim();
+
+if (databaseUrl) {
+	const parsed = new URL(databaseUrl);
+	const hasHost = parsed.hostname.length > 0;
+	const hasSocketHost = parsed.searchParams.has("host");
+
+	if (!hasHost && !hasSocketHost) {
+		console.error(
+			"Invalid DATABASE_URL: DATABASE_URL must include a hostname or host query parameter."
+		);
+		process.exit(1);
+	}
+}
 
 if (isProductionLike() && !databaseUrl) {
 	console.error("DATABASE_URL is required for production drizzle commands.");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,7 +10,7 @@ import {
   provisionUserSettings,
 } from "$lib/server/account-settings";
 
-const authBaseUrl = env.BETTER_AUTH_URL || "http://localhost:4180";
+const authBaseUrl = env.BETTER_AUTH_URL?.trim() || undefined;
 const authSecret =
   env.BETTER_AUTH_SECRET || "development-only-secret-development-only-secret";
 const adminEmails = parseAdminEmails(env.ADMIN_EMAILS);
@@ -31,6 +31,9 @@ export const auth = betterAuth({
   secret: authSecret,
   baseURL: authBaseUrl,
   basePath: "/api/auth",
+  advanced: {
+    trustedProxyHeaders: true,
+  },
   trustedOrigins: (request) => {
     const requestOrigin = getRequestOrigin(request);
 

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -21,7 +21,29 @@ function isProductionLike() {
 
 function getConfiguredDatabaseUrl() {
   if (env.DATABASE_URL) {
-    return env.DATABASE_URL;
+    const databaseUrl = env.DATABASE_URL.trim();
+
+    if (databaseUrl.length === 0) {
+      return null;
+    }
+
+    try {
+      const parsed = new URL(databaseUrl);
+      const hasHost = parsed.hostname.length > 0;
+      const hasSocketHost = parsed.searchParams.has("host");
+
+      if (!hasHost && !hasSocketHost) {
+        throw new Error(
+          "DATABASE_URL must include a hostname or host query parameter.",
+        );
+      }
+
+      return databaseUrl;
+    } catch (error) {
+      throw new Error(
+        `Invalid DATABASE_URL: ${error instanceof Error ? error.message : "failed to parse database url."}`,
+      );
+    }
   }
 
   return null;


### PR DESCRIPTION
## 概要
本番環境で発生していた DB 接続エラーと OAuth リダイレクト不整合を修正します。

## 変更内容
- 本番の Better Auth callback URL が `localhost` にならないよう、認証 base URL をリクエスト origin ベースで解決するよう修正
- `DATABASE_URL` が空文字や host なしの不正値だった場合に、localhost fallback へ落ちる前に明示的にエラーにするガードを追加
- drizzle / scripts / アプリ本体で `DATABASE_URL` の検証ロジックを統一

## 確認内容
- `pnpm check`
- `pnpm build`

## 補足
- 本番では `BETTER_AUTH_URL` を本番ドメインに設定するか、未設定にしてデプロイ先 origin を使う想定です
- `DATABASE_URL` は `postgresql://user:password@host:port/dbname` のように host を含む形式が必要です
