### PR TITLE
feat: タイムライン投稿・コメント・リアクションを実データ化

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "drizzle-orm": "0.41.0",
     "heic-to": "^1.4.2",
     "lucide-svelte": "^0.562.0",
+    "motion": "^12.35.1",
     "postgres": "^3.4.5",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       lucide-svelte:
         specifier: ^0.562.0
         version: 0.562.0(svelte@5.47.1)
+      motion:
+        specifier: ^12.35.1
+        version: 12.35.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -3019,6 +3022,23 @@ packages:
         integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==,
       }
 
+  framer-motion@12.35.1:
+    resolution:
+      {
+        integrity: sha512-rL8cLrjYZNShZqKV3U0Qj6Y5WDiZXYEM5giiTLfEqsIZxtspzMDCkKmrO5po76jWfvOg04+Vk+sfBvTD0iMmLw==,
+      }
+    peerDependencies:
+      "@emotion/is-prop-valid": "*"
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      "@emotion/is-prop-valid":
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-constants@1.0.0:
     resolution:
       {
@@ -3545,6 +3565,35 @@ packages:
       snappy:
         optional: true
       socks:
+        optional: true
+
+  motion-dom@12.35.1:
+    resolution:
+      {
+        integrity: sha512-7n6r7TtNOsH2UFSAXzTkfzOeO5616v9B178qBIjmu/WgEyJK0uqwytCEhwKBTuM/HJA40ptAw7hLFpxtPAMRZQ==,
+      }
+
+  motion-utils@12.29.2:
+    resolution:
+      {
+        integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==,
+      }
+
+  motion@12.35.1:
+    resolution:
+      {
+        integrity: sha512-yEt/49kWC0VU/IEduDfeZw82eDemlPwa1cyo/gcEEUCN4WgpSJpUcxz6BUwakGabvJiTzLQ58J73515I5tfykQ==,
+      }
+    peerDependencies:
+      "@emotion/is-prop-valid": "*"
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      "@emotion/is-prop-valid":
+        optional: true
+      react:
+        optional: true
+      react-dom:
         optional: true
 
   mri@1.2.0:
@@ -6218,6 +6267,15 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  framer-motion@12.35.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.35.1
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
@@ -6445,6 +6503,20 @@ snapshots:
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
     optional: true
+
+  motion-dom@12.35.1:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
+
+  motion@12.35.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 12.35.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   mri@1.2.0: {}
 
@@ -6922,8 +6994,7 @@ snapshots:
       punycode: 2.3.1
     optional: true
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/src/lib/components/projects/ProjectCard.svelte
+++ b/src/lib/components/projects/ProjectCard.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { getUser } from "$lib/stores/mock";
     import {
         getProjectHelpTypeInfo,
         getProjectStageInfo,
@@ -29,10 +28,11 @@
 
     export let project: ProjectCardProject;
 
-    $: ownerStore = getUser(project.ownerId);
     $: owner = {
-        name: project.ownerName ?? $ownerStore?.name,
-        avatarUrl: project.ownerAvatarUrl ?? $ownerStore?.avatarUrl,
+        name: project.ownerName ?? "Unknown",
+        avatarUrl:
+            project.ownerAvatarUrl ??
+            `https://i.pravatar.cc/150?u=${encodeURIComponent(project.ownerId)}`,
     };
     $: statusInfo = getProjectStatusInfo(project.status);
     $: stageInfo = getProjectStageInfo(project.projectStage ?? null);

--- a/src/lib/components/shared/ReactionBar.svelte
+++ b/src/lib/components/shared/ReactionBar.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
-    import { api, reactions, currentUser } from "$lib/stores/mock";
+    import { goto, invalidate } from "$app/navigation";
+    import { page } from "$app/stores";
+    import { sessionUser } from "$lib/stores/session";
+    import type { ReactionTargetType } from "$lib/shared/domain";
+    import {
+        createEmptyTimelineReactionSummary,
+        type TimelineReactionSummary,
+    } from "$lib/shared/timeline";
     import { Heart, Lightbulb, Flame, LifeBuoy, Hand } from "lucide-svelte";
     import clsx from "clsx";
 
     export let targetId: string;
-    export let targetType: "project" | "post" | "comment";
+    export let targetType: ReactionTargetType;
+    export let reactions: TimelineReactionSummary[] =
+        createEmptyTimelineReactionSummary();
+    export let invalidateKey: string | null = null;
 
-    // 5 kinds: clap, like, idea, fire, help
-    // Map icons
+    let currentReactions = reactions.map((reaction) => ({ ...reaction }));
+    let errorMessage = "";
+    let isSubmitting = false;
+    let lastReactionSignature = "";
+
     const REACTION_CONFIG = [
         { kind: "clap", icon: Hand, label: "拍手", color: "text-yellow-500" },
         { kind: "like", icon: Heart, label: "いいね", color: "text-pink-500" },
@@ -26,44 +39,113 @@
         },
     ] as const;
 
-    $: currentReactions = $reactions.filter(
-        (r) => r.targetId === targetId && r.targetType === targetType,
-    );
-    $: myUserId = $currentUser?.id;
-
-    function handleToggle(kind: (typeof REACTION_CONFIG)[number]["kind"]) {
-        if (!myUserId) return; // TODO: Prompt login
-        api.toggleReaction(targetId, targetType, kind, myUserId);
+    function getReactionSignature(value: TimelineReactionSummary[]) {
+        return value
+            .map(
+                (item) =>
+                    `${item.kind}:${item.count}:${item.reactedByMe ? "1" : "0"}`,
+            )
+            .join("|");
     }
 
+    $: {
+        const nextSignature = getReactionSignature(reactions);
+
+        if (nextSignature !== lastReactionSignature && !isSubmitting) {
+            currentReactions = reactions.map((reaction) => ({ ...reaction }));
+            lastReactionSignature = nextSignature;
+        }
+    }
+
+    $: loginHref = `/login?next=${encodeURIComponent(
+        `${$page.url.pathname}${$page.url.search}`,
+    )}`;
+
     function getCount(kind: string) {
-        return currentReactions.filter((r) => r.kind === kind).length;
+        return currentReactions.find((reaction) => reaction.kind === kind)?.count ?? 0;
     }
 
     function doIReact(kind: string) {
         return currentReactions.some(
-            (r) => r.kind === kind && r.userId === myUserId,
+            (reaction) => reaction.kind === kind && reaction.reactedByMe,
         );
+    }
+
+    async function handleToggle(kind: (typeof REACTION_CONFIG)[number]["kind"]) {
+        if (isSubmitting) {
+            return;
+        }
+
+        if (!$sessionUser) {
+            await goto(loginHref);
+            return;
+        }
+
+        errorMessage = "";
+        isSubmitting = true;
+
+        try {
+            const method = doIReact(kind) ? "DELETE" : "POST";
+            const response = await fetch("/api/reactions", {
+                method,
+                headers: {
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    targetId,
+                    targetType,
+                    kind,
+                }),
+            });
+
+            const payload = (await response.json().catch(() => null)) as
+                | { message?: string; reactions?: TimelineReactionSummary[] }
+                | null;
+
+            if (!response.ok) {
+                errorMessage =
+                    payload?.message ?? "リアクションの更新に失敗しました。";
+                return;
+            }
+
+            currentReactions = (
+                payload?.reactions ?? createEmptyTimelineReactionSummary()
+            ).map((reaction) => ({ ...reaction }));
+            lastReactionSignature = getReactionSignature(currentReactions);
+
+            if (invalidateKey) {
+                await invalidate(invalidateKey);
+            }
+        } finally {
+            isSubmitting = false;
+        }
     }
 </script>
 
-<div class="flex flex-wrap gap-2">
-    {#each REACTION_CONFIG as { kind, icon, label, color }}
-        <button
-            class={clsx(
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all",
-                doIReact(kind)
-                    ? `bg-gray-100 ${color} ring-1 ring-inset ring-gray-200`
-                    : "hover:bg-gray-50 text-gray-500",
-            )}
-            title={label}
-            on:click={() => handleToggle(kind)}
-        >
-            <svelte:component
-                this={icon}
-                class={clsx("w-4 h-4", doIReact(kind) && "fill-current")}
-            />
-            <span>{getCount(kind) || ""}</span>
-        </button>
-    {/each}
+<div class="flex flex-col gap-2">
+    <div class="flex flex-wrap gap-2">
+        {#each REACTION_CONFIG as { kind, icon, label, color }}
+            <button
+                class={clsx(
+                    "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all disabled:opacity-60",
+                    doIReact(kind)
+                        ? `bg-gray-100 ${color} ring-1 ring-inset ring-gray-200`
+                        : "hover:bg-gray-50 text-gray-500",
+                )}
+                title={label}
+                disabled={isSubmitting}
+                on:click={() => handleToggle(kind)}
+            >
+                <svelte:component
+                    this={icon}
+                    class={clsx("w-4 h-4", doIReact(kind) && "fill-current")}
+                />
+                <span>{getCount(kind) || ""}</span>
+            </button>
+        {/each}
+    </div>
+
+    {#if errorMessage}
+        <p class="text-xs text-rose-600">{errorMessage}</p>
+    {/if}
 </div>

--- a/src/lib/components/shared/ReactionBar.svelte
+++ b/src/lib/components/shared/ReactionBar.svelte
@@ -2,13 +2,15 @@
     import { goto, invalidate } from "$app/navigation";
     import { page } from "$app/stores";
     import { sessionUser } from "$lib/stores/session";
-    import type { ReactionTargetType } from "$lib/shared/domain";
+    import type { ReactionKind, ReactionTargetType } from "$lib/shared/domain";
     import {
         createEmptyTimelineReactionSummary,
         type TimelineReactionSummary,
     } from "$lib/shared/timeline";
     import { Heart, Lightbulb, Flame, LifeBuoy, Hand } from "lucide-svelte";
     import clsx from "clsx";
+    import { animate, type DOMKeyframesDefinition } from "motion";
+    import { tick } from "svelte";
 
     export let targetId: string;
     export let targetType: ReactionTargetType;
@@ -16,28 +18,63 @@
         createEmptyTimelineReactionSummary();
     export let invalidateKey: string | null = null;
 
-    let currentReactions = reactions.map((reaction) => ({ ...reaction }));
+    type ReactionDelta = -1 | 1;
+    type ReactionDisplay = (typeof REACTION_CONFIG)[number] & {
+        count: number;
+        reactedByMe: boolean;
+    };
+
+    let currentReactions = cloneReactionSummary(reactions);
     let errorMessage = "";
     let isSubmitting = false;
-    let lastReactionSignature = "";
+    let lastPropReactionSignature = "";
+    let reactionStateMap = new Map<
+        ReactionKind,
+        { count: number; reactedByMe: boolean }
+    >();
+    let displayReactions: ReactionDisplay[] = [];
 
     const REACTION_CONFIG = [
-        { kind: "clap", icon: Hand, label: "拍手", color: "text-yellow-500" },
-        { kind: "like", icon: Heart, label: "いいね", color: "text-pink-500" },
+        {
+            kind: "clap",
+            icon: Hand,
+            label: "拍手",
+            accent: "234 179 8",
+            accentSoft: "254 252 232",
+        },
+        {
+            kind: "like",
+            icon: Heart,
+            label: "いいね",
+            accent: "236 72 153",
+            accentSoft: "253 242 248",
+        },
         {
             kind: "idea",
             icon: Lightbulb,
             label: "なるほど",
-            color: "text-yellow-400",
+            accent: "250 204 21",
+            accentSoft: "254 249 195",
         },
-        { kind: "fire", icon: Flame, label: "アツい", color: "text-red-500" },
+        {
+            kind: "fire",
+            icon: Flame,
+            label: "アツい",
+            accent: "239 68 68",
+            accentSoft: "254 242 242",
+        },
         {
             kind: "help",
             icon: LifeBuoy,
             label: "助ける",
-            color: "text-blue-500",
+            accent: "59 130 246",
+            accentSoft: "239 246 255",
         },
     ] as const;
+
+    function cloneReactionSummary(value: TimelineReactionSummary[]) {
+        return value.map((reaction) => ({ ...reaction }));
+    }
 
     function getReactionSignature(value: TimelineReactionSummary[]) {
         return value
@@ -48,12 +85,149 @@
             .join("|");
     }
 
+    function toggleReactionPreview(kind: ReactionKind) {
+        currentReactions = currentReactions.map((reaction) => {
+            if (reaction.kind !== kind) {
+                return { ...reaction };
+            }
+
+            const nextReactedByMe = !reaction.reactedByMe;
+
+            return {
+                ...reaction,
+                reactedByMe: nextReactedByMe,
+                count: Math.max(0, reaction.count + (nextReactedByMe ? 1 : -1)),
+            };
+        });
+    }
+
+    function cancelReactionAnimations(button: HTMLButtonElement) {
+        const animationTargets = [
+            button.querySelector<HTMLElement>("[data-reaction-glow]"),
+            button.querySelector<HTMLElement>("[data-reaction-icon]"),
+            button.querySelector<HTMLElement>("[data-reaction-count]"),
+            button.querySelector<HTMLElement>("[data-reaction-feedback]"),
+        ].filter((element): element is HTMLElement => Boolean(element));
+
+        for (const target of animationTargets) {
+            for (const animation of target.getAnimations()) {
+                animation.cancel();
+            }
+        }
+    }
+
+    function animateDomElement(
+        target: Element,
+        keyframes: DOMKeyframesDefinition,
+        options: {
+            duration: number;
+            ease: "ease-out";
+        },
+    ) {
+        return (animate as unknown as typeof animate & ((...args: any[]) => unknown))(
+            target,
+            keyframes,
+            options,
+        );
+    }
+
+    function playReactionAnimation(
+        button: HTMLButtonElement,
+        delta: ReactionDelta,
+        nextReactedByMe: boolean,
+    ) {
+        const glow = button.querySelector<HTMLElement>("[data-reaction-glow]");
+        const icon = button.querySelector<HTMLElement>("[data-reaction-icon]");
+        const count = button.querySelector<HTMLElement>("[data-reaction-count]");
+        const feedback = button.querySelector<HTMLElement>(
+            "[data-reaction-feedback]",
+        );
+
+        cancelReactionAnimations(button);
+
+        if (feedback) {
+            feedback.textContent = delta === -1 ? "-1" : "+1";
+        }
+
+        if (glow) {
+            const glowKeyframes: DOMKeyframesDefinition = {
+                opacity: nextReactedByMe
+                    ? [0.1, 0.5, 0.32]
+                    : [0.26, 0.44, 0],
+                scale: nextReactedByMe ? [0.78, 1.16, 1] : [1, 1.08, 0.82],
+            };
+
+            animateDomElement(
+                glow,
+                glowKeyframes,
+                {
+                    duration: 0.42,
+                    ease: "ease-out",
+                },
+            );
+        }
+
+        if (icon) {
+            const iconKeyframes: DOMKeyframesDefinition = {
+                scale: nextReactedByMe
+                    ? [0.88, 1.28, 1]
+                    : [1, 0.82, 1.08, 1],
+                rotate: nextReactedByMe
+                    ? [-14, 10, 0]
+                    : [0, -10, 6, 0],
+            };
+
+            animateDomElement(
+                icon,
+                iconKeyframes,
+                {
+                    duration: 0.34,
+                    ease: "ease-out",
+                },
+            );
+        }
+
+        if (count) {
+            const countKeyframes: DOMKeyframesDefinition = {
+                y: [5, -4, 0],
+                opacity: [0.45, 1, 1],
+                scale: [0.88, 1.14, 1],
+            };
+
+            animateDomElement(
+                count,
+                countKeyframes,
+                {
+                    duration: 0.3,
+                    ease: "ease-out",
+                },
+            );
+        }
+
+        if (feedback) {
+            const feedbackKeyframes: DOMKeyframesDefinition = {
+                opacity: [0, 1, 0],
+                y: [8, -2, -16],
+                scale: [0.84, 1, 1.04],
+            };
+
+            animateDomElement(
+                feedback,
+                feedbackKeyframes,
+                {
+                    duration: 0.52,
+                    ease: "ease-out",
+                },
+            );
+        }
+    }
+
     $: {
         const nextSignature = getReactionSignature(reactions);
 
-        if (nextSignature !== lastReactionSignature && !isSubmitting) {
-            currentReactions = reactions.map((reaction) => ({ ...reaction }));
-            lastReactionSignature = nextSignature;
+        if (nextSignature !== lastPropReactionSignature && !isSubmitting) {
+            currentReactions = cloneReactionSummary(reactions);
+            lastPropReactionSignature = nextSignature;
         }
     }
 
@@ -61,17 +235,44 @@
         `${$page.url.pathname}${$page.url.search}`,
     )}`;
 
-    function getCount(kind: string) {
-        return currentReactions.find((reaction) => reaction.kind === kind)?.count ?? 0;
+    $: reactionStateMap = new Map(
+        currentReactions.map((reaction) => [
+            reaction.kind,
+            {
+                count: reaction.count,
+                reactedByMe: reaction.reactedByMe,
+            },
+        ]),
+    );
+
+    $: displayReactions = REACTION_CONFIG.map((reaction) => {
+        const state = reactionStateMap.get(reaction.kind);
+
+        return {
+            ...reaction,
+            count: state?.count ?? 0,
+            reactedByMe: state?.reactedByMe ?? false,
+        };
+    });
+
+    function getReactionState(kind: ReactionKind) {
+        return reactionStateMap.get(kind) ?? { count: 0, reactedByMe: false };
     }
 
-    function doIReact(kind: string) {
-        return currentReactions.some(
-            (reaction) => reaction.kind === kind && reaction.reactedByMe,
-        );
+    function getReactionButtonStyle(reaction: ReactionDisplay) {
+        const baseStyle = `--reaction-accent: ${reaction.accent}; --reaction-accent-soft: ${reaction.accentSoft};`;
+
+        if (!reaction.reactedByMe) {
+            return baseStyle;
+        }
+
+        return `${baseStyle} color: rgb(${reaction.accent}); background: rgb(${reaction.accentSoft}); box-shadow: inset 0 0 0 1px rgb(${reaction.accent} / 0.18), 0 14px 24px -22px rgb(${reaction.accent} / 0.45);`;
     }
 
-    async function handleToggle(kind: (typeof REACTION_CONFIG)[number]["kind"]) {
+    async function handleToggle(
+        kind: (typeof REACTION_CONFIG)[number]["kind"],
+        button: HTMLButtonElement,
+    ) {
         if (isSubmitting) {
             return;
         }
@@ -84,8 +285,16 @@
         errorMessage = "";
         isSubmitting = true;
 
+        const hadReacted = getReactionState(kind).reactedByMe;
+        const previousReactions = cloneReactionSummary(currentReactions);
+        const nextReactedByMe = !hadReacted;
+
+        toggleReactionPreview(kind);
+        await tick();
+        playReactionAnimation(button, hadReacted ? -1 : 1, nextReactedByMe);
+
         try {
-            const method = doIReact(kind) ? "DELETE" : "POST";
+            const method = hadReacted ? "DELETE" : "POST";
             const response = await fetch("/api/reactions", {
                 method,
                 headers: {
@@ -103,19 +312,25 @@
                 | null;
 
             if (!response.ok) {
+                currentReactions = previousReactions;
                 errorMessage =
                     payload?.message ?? "リアクションの更新に失敗しました。";
                 return;
             }
 
-            currentReactions = (
-                payload?.reactions ?? createEmptyTimelineReactionSummary()
-            ).map((reaction) => ({ ...reaction }));
-            lastReactionSignature = getReactionSignature(currentReactions);
+            currentReactions = cloneReactionSummary(
+                payload?.reactions ?? currentReactions,
+            );
 
             if (invalidateKey) {
-                await invalidate(invalidateKey);
+                void invalidate(invalidateKey);
             }
+        } catch (error) {
+            currentReactions = previousReactions;
+            errorMessage =
+                error instanceof Error
+                    ? error.message
+                    : "リアクションの更新に失敗しました。";
         } finally {
             isSubmitting = false;
         }
@@ -124,23 +339,43 @@
 
 <div class="flex flex-col gap-2">
     <div class="flex flex-wrap gap-2">
-        {#each REACTION_CONFIG as { kind, icon, label, color }}
+        {#each displayReactions as reaction (reaction.kind)}
             <button
                 class={clsx(
-                    "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all disabled:opacity-60",
-                    doIReact(kind)
-                        ? `bg-gray-100 ${color} ring-1 ring-inset ring-gray-200`
-                        : "hover:bg-gray-50 text-gray-500",
+                    "reaction-button group relative isolate flex items-center gap-1.5 overflow-visible rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200 hover:-translate-y-0.5",
+                    reaction.reactedByMe && "is-reacted",
                 )}
-                title={label}
-                disabled={isSubmitting}
-                on:click={() => handleToggle(kind)}
+                style={getReactionButtonStyle(reaction)}
+                aria-pressed={reaction.reactedByMe}
+                title={reaction.label}
+                on:click={(event) =>
+                    handleToggle(
+                        reaction.kind,
+                        event.currentTarget as HTMLButtonElement,
+                    )}
             >
+                <span
+                    class={clsx(
+                        "reaction-glow",
+                        reaction.reactedByMe && "is-reacted",
+                    )}
+                    data-reaction-glow
+                    aria-hidden="true"
+                ></span>
                 <svelte:component
-                    this={icon}
-                    class={clsx("w-4 h-4", doIReact(kind) && "fill-current")}
+                    this={reaction.icon}
+                    class={clsx(
+                        "reaction-icon relative z-10 h-4 w-4",
+                        reaction.reactedByMe && "fill-current",
+                    )}
+                    data-reaction-icon
                 />
-                <span>{getCount(kind) || ""}</span>
+                <span class="reaction-count relative z-10 min-w-[0.75rem]" data-reaction-count>
+                    {reaction.count || ""}
+                </span>
+                <span class="reaction-feedback" data-reaction-feedback aria-hidden="true">
+                    +1
+                </span>
             </button>
         {/each}
     </div>
@@ -149,3 +384,62 @@
         <p class="text-xs text-rose-600">{errorMessage}</p>
     {/if}
 </div>
+
+<style>
+    .reaction-button {
+        transform: translateZ(0);
+        color: rgb(107 114 128);
+        background: rgb(255 255 255);
+    }
+
+    .reaction-button:hover {
+        background: rgb(249 250 251);
+    }
+
+    .reaction-button.is-reacted {
+        color: rgb(var(--reaction-accent));
+        background: rgb(var(--reaction-accent-soft));
+        box-shadow:
+            0 0 0 1px rgb(var(--reaction-accent) / 0.18) inset,
+            0 14px 24px -22px rgb(var(--reaction-accent) / 0.45);
+    }
+
+    .reaction-button.is-reacted:hover {
+        background: rgb(var(--reaction-accent-soft));
+    }
+
+    .reaction-glow {
+        position: absolute;
+        inset: -1px;
+        border-radius: 9999px;
+        pointer-events: none;
+        opacity: 0;
+        transform: scale(0.65);
+        background:
+            radial-gradient(
+                circle at center,
+                rgba(255, 255, 255, 0.96) 0%,
+                rgb(var(--reaction-accent) / 0.28) 42%,
+                rgb(var(--reaction-accent) / 0) 74%
+            );
+    }
+
+    .reaction-glow.is-reacted {
+        opacity: 0.32;
+        transform: scale(1);
+    }
+
+    .reaction-feedback {
+        position: absolute;
+        top: -0.75rem;
+        left: 50%;
+        z-index: 20;
+        pointer-events: none;
+        font-size: 0.7rem;
+        font-weight: 700;
+        color: rgb(var(--reaction-accent));
+        text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
+        opacity: 0;
+        transform: translate(-50%, 0.35rem) scale(0.85);
+    }
+</style>

--- a/src/lib/components/timeline/CommentSection.svelte
+++ b/src/lib/components/timeline/CommentSection.svelte
@@ -32,6 +32,16 @@
     let errorMessage = "";
     let lastCommentsSignature = "";
 
+    function syncAcceptedComment(
+        value: TimelineCommentView[],
+        nextAcceptedCommentId: string | null,
+    ) {
+        return value.map((comment) => ({
+            ...comment,
+            isAccepted: comment.id === nextAcceptedCommentId,
+        }));
+    }
+
     function getCommentSignature(value: TimelineCommentView[]) {
         return value
             .map(
@@ -56,12 +66,25 @@
             !isLoadingAll &&
             !isSolving
         ) {
-            currentComments = comments.map((comment) => ({ ...comment }));
-            currentCommentCount = commentCount;
             localAcceptedCommentId = acceptedCommentId;
             localCanSolve = canSolve;
             hasLoadedAllComments = hasLoadedAllComments || hasFullComments;
             showAll = showAll || defaultShowAll || hasFullComments;
+
+            if (hasLoadedAllComments && !hasFullComments) {
+                currentComments = syncAcceptedComment(
+                    currentComments,
+                    acceptedCommentId,
+                );
+                currentCommentCount = Math.max(commentCount, currentComments.length);
+            } else {
+                currentComments = syncAcceptedComment(
+                    comments.map((comment) => ({ ...comment })),
+                    acceptedCommentId,
+                );
+                currentCommentCount = commentCount;
+            }
+
             lastCommentsSignature = nextSignature;
         }
     }
@@ -88,9 +111,12 @@
             );
         }
 
-        currentComments = (payload?.comments ?? []).map((comment) => ({
-            ...comment,
-        }));
+        currentComments = syncAcceptedComment(
+            (payload?.comments ?? []).map((comment) => ({
+                ...comment,
+            })),
+            localAcceptedCommentId,
+        );
         currentCommentCount = currentComments.length;
         hasLoadedAllComments = true;
         lastCommentsSignature = [
@@ -208,10 +234,7 @@
 
             localAcceptedCommentId = commentId;
             localCanSolve = false;
-            currentComments = currentComments.map((comment) => ({
-                ...comment,
-                isAccepted: comment.id === commentId,
-            }));
+            currentComments = syncAcceptedComment(currentComments, commentId);
 
             if (invalidateKey) {
                 await invalidate(invalidateKey);

--- a/src/lib/components/timeline/CommentSection.svelte
+++ b/src/lib/components/timeline/CommentSection.svelte
@@ -1,62 +1,250 @@
 <script lang="ts">
+    import { invalidate } from "$app/navigation";
     import { page } from "$app/stores";
-    import { api, comments, currentUser, users } from "$lib/stores/mock";
+    import { sessionUser } from "$lib/stores/session";
+    import type { CommentTargetType } from "$lib/shared/domain";
+    import type { TimelineCommentView } from "$lib/shared/timeline";
     import { Send, Star, Check } from "lucide-svelte";
     import clsx from "clsx";
     import { formatDistanceToNow } from "date-fns";
     import { ja } from "date-fns/locale";
 
     export let targetId: string;
-    export let targetType: "project" | "post" | "comment";
-    export let canSolve = false; // If true, show "Accept Answer" buttons
-    export let acceptedCommentId: string | undefined = undefined;
-    export let onSolve: (commentId: string) => void = () => {};
+    export let targetType: CommentTargetType;
+    export let comments: TimelineCommentView[] = [];
+    export let commentCount = 0;
+    export let canSolve = false;
+    export let acceptedCommentId: string | null = null;
+    export let defaultShowAll = false;
+    export let hasFullComments = false;
+    export let invalidateKey: string | null = null;
 
     let newCommentBody = "";
-    let showAll = false;
+    let showAll = defaultShowAll;
+    let hasLoadedAllComments = hasFullComments;
+    let localCanSolve = canSolve;
+    let localAcceptedCommentId = acceptedCommentId;
+    let currentComments = comments.map((comment) => ({ ...comment }));
+    let currentCommentCount = commentCount;
+    let isSubmitting = false;
+    let isLoadingAll = false;
+    let isSolving = false;
+    let errorMessage = "";
+    let lastCommentsSignature = "";
 
-    $: allComments = $comments.filter(
-        (c) => c.targetId === targetId && c.targetType === targetType,
-    );
-    $: visibleComments = showAll ? allComments : allComments.slice(-3); // Show last 3 by default
-    $: hasMore = allComments.length > visibleComments.length;
+    function getCommentSignature(value: TimelineCommentView[]) {
+        return value
+            .map(
+                (comment) =>
+                    `${comment.id}:${comment.isAccepted ? "1" : "0"}:${comment.body}`,
+            )
+            .join("|");
+    }
+
+    $: {
+        const nextSignature = [
+            commentCount,
+            acceptedCommentId ?? "",
+            canSolve ? "1" : "0",
+            hasFullComments ? "1" : "0",
+            getCommentSignature(comments),
+        ].join("|");
+
+        if (
+            nextSignature !== lastCommentsSignature &&
+            !isSubmitting &&
+            !isLoadingAll &&
+            !isSolving
+        ) {
+            currentComments = comments.map((comment) => ({ ...comment }));
+            currentCommentCount = commentCount;
+            localAcceptedCommentId = acceptedCommentId;
+            localCanSolve = canSolve;
+            hasLoadedAllComments = hasLoadedAllComments || hasFullComments;
+            showAll = showAll || defaultShowAll || hasFullComments;
+            lastCommentsSignature = nextSignature;
+        }
+    }
+
+    $: visibleComments = showAll
+        ? currentComments
+        : currentComments.slice(-3);
+    $: hasMore = currentCommentCount > currentComments.length;
     $: loginHref = `/login?next=${encodeURIComponent(
         `${$page.url.pathname}${$page.url.search}`,
     )}`;
 
-    function handleAdd() {
-        if (!$currentUser) return;
-        if (!newCommentBody.trim()) return;
+    async function fetchAllComments() {
+        const response = await fetch(
+            `/api/comments?targetType=${encodeURIComponent(targetType)}&targetId=${encodeURIComponent(targetId)}`,
+        );
+        const payload = (await response.json().catch(() => null)) as
+            | { comments?: TimelineCommentView[]; message?: string }
+            | null;
 
-        api.addComment({
-            targetId,
-            targetType,
-            authorId: $currentUser.id,
-            body: newCommentBody,
-        });
-        newCommentBody = "";
+        if (!response.ok) {
+            throw new Error(
+                payload?.message ?? "コメント一覧の取得に失敗しました。",
+            );
+        }
+
+        currentComments = (payload?.comments ?? []).map((comment) => ({
+            ...comment,
+        }));
+        currentCommentCount = currentComments.length;
+        hasLoadedAllComments = true;
+        lastCommentsSignature = [
+            currentCommentCount,
+            localAcceptedCommentId ?? "",
+            localCanSolve ? "1" : "0",
+            "1",
+            getCommentSignature(currentComments),
+        ].join("|");
+    }
+
+    async function handleShowAll() {
+        if (showAll || isLoadingAll) {
+            return;
+        }
+
+        errorMessage = "";
+
+        if (!hasLoadedAllComments && hasMore) {
+            isLoadingAll = true;
+
+            try {
+                await fetchAllComments();
+            } catch (error) {
+                errorMessage =
+                    error instanceof Error
+                        ? error.message
+                        : "コメント一覧の取得に失敗しました。";
+                isLoadingAll = false;
+                return;
+            }
+
+            isLoadingAll = false;
+        }
+
         showAll = true;
     }
 
-    function getAuthor(id: string) {
-        return $users.find((u) => u.id === id);
+    async function handleAdd() {
+        if (!$sessionUser || !newCommentBody.trim() || isSubmitting) {
+            return;
+        }
+
+        errorMessage = "";
+        isSubmitting = true;
+
+        try {
+            const response = await fetch("/api/comments", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    targetId,
+                    targetType,
+                    body: newCommentBody,
+                }),
+            });
+
+            const payload = (await response.json().catch(() => null)) as
+                | { message?: string }
+                | null;
+
+            if (!response.ok) {
+                errorMessage =
+                    payload?.message ?? "コメントの投稿に失敗しました。";
+                return;
+            }
+
+            newCommentBody = "";
+            await fetchAllComments();
+            showAll = true;
+
+            if (invalidateKey) {
+                await invalidate(invalidateKey);
+            }
+        } catch (error) {
+            errorMessage =
+                error instanceof Error
+                    ? error.message
+                    : "コメントの投稿に失敗しました。";
+        } finally {
+            isSubmitting = false;
+        }
+    }
+
+    async function handleSolve(commentId: string) {
+        if (!localCanSolve || isSolving) {
+            return;
+        }
+
+        errorMessage = "";
+        isSolving = true;
+
+        try {
+            const response = await fetch(`/api/timeline/${targetId}/solve`, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    acceptedCommentId: commentId,
+                }),
+            });
+
+            const payload = (await response.json().catch(() => null)) as
+                | { message?: string }
+                | null;
+
+            if (!response.ok) {
+                errorMessage =
+                    payload?.message ?? "解決済みへの更新に失敗しました。";
+                return;
+            }
+
+            localAcceptedCommentId = commentId;
+            localCanSolve = false;
+            currentComments = currentComments.map((comment) => ({
+                ...comment,
+                isAccepted: comment.id === commentId,
+            }));
+
+            if (invalidateKey) {
+                await invalidate(invalidateKey);
+            }
+        } catch (error) {
+            errorMessage =
+                error instanceof Error
+                    ? error.message
+                    : "解決済みへの更新に失敗しました。";
+        } finally {
+            isSolving = false;
+        }
     }
 </script>
 
 <div class="mt-3 pt-2">
     {#if hasMore && !showAll}
         <button
-            class="text-xs text-gray-500 hover:text-indigo-600 mb-2"
-            on:click={() => (showAll = true)}
+            class="text-xs text-gray-500 hover:text-indigo-600 mb-2 disabled:opacity-60"
+            disabled={isLoadingAll}
+            on:click={handleShowAll}
         >
-            以前のコメントをすべて見る ({allComments.length})
+            {#if isLoadingAll}
+                コメントを読み込み中...
+            {:else}
+                以前のコメントをすべて見る ({currentCommentCount})
+            {/if}
         </button>
     {/if}
 
     <div class="space-y-3 mb-3">
         {#each visibleComments as comment (comment.id)}
-            {@const author = getAuthor(comment.authorId)}
-            {@const isAccepted = comment.id === acceptedCommentId}
+            {@const isAccepted = comment.id === localAcceptedCommentId}
 
             <div
                 class={clsx(
@@ -65,14 +253,15 @@
                 )}
             >
                 <img
-                    src={author?.avatarUrl}
+                    src={comment.author.avatarUrl ||
+                        `https://i.pravatar.cc/150?u=${encodeURIComponent(comment.author.id)}`}
                     alt=""
                     class="w-8 h-8 rounded-full bg-gray-200 flex-shrink-0"
                 />
                 <div class="flex-1">
                     <div class="flex justify-between items-start">
                         <div class="font-bold text-gray-900">
-                            {author?.name}
+                            {comment.author.displayName}
                         </div>
                         <div class="text-xs text-gray-400">
                             {formatDistanceToNow(new Date(comment.createdAt), {
@@ -90,10 +279,11 @@
                         >
                             <Star class="w-3 h-3 mr-1 fill-current" /> ベストアンサー
                         </div>
-                    {:else if canSolve}
+                    {:else if localCanSolve}
                         <button
-                            class="mt-1 opacity-0 group-hover:opacity-100 transition-opacity text-xs flex items-center text-gray-400 hover:text-green-600"
-                            on:click={() => onSolve(comment.id)}
+                            class="mt-1 opacity-0 group-hover:opacity-100 transition-opacity text-xs flex items-center text-gray-400 hover:text-green-600 disabled:opacity-60"
+                            disabled={isSolving}
+                            on:click={() => handleSolve(comment.id)}
                         >
                             <Check class="w-3 h-3 mr-1" /> これで解決にする
                         </button>
@@ -103,18 +293,18 @@
         {/each}
     </div>
 
-    {#if $currentUser}
+    {#if $sessionUser}
         <div class="relative">
             <input
                 type="text"
                 bind:value={newCommentBody}
                 placeholder="コメントを書く..."
                 class="w-full text-sm rounded-full border-gray-300 pl-4 pr-10 py-2 focus:ring-indigo-500 focus:border-indigo-500 bg-gray-50 hover:bg-white transition-colors"
-                on:keydown={(e) => e.key === "Enter" && handleAdd()}
+                on:keydown={(event) => event.key === "Enter" && handleAdd()}
             />
             <button
                 class="absolute right-2 top-1.5 text-indigo-600 hover:text-indigo-800 disabled:opacity-50"
-                disabled={!newCommentBody}
+                disabled={!newCommentBody.trim() || isSubmitting}
                 on:click={handleAdd}
             >
                 <Send class="w-4 h-4" />
@@ -128,5 +318,9 @@
             </a>
             してください。
         </div>
+    {/if}
+
+    {#if errorMessage}
+        <p class="mt-2 text-xs text-rose-600">{errorMessage}</p>
     {/if}
 </div>

--- a/src/lib/components/timeline/CommentSection.svelte
+++ b/src/lib/components/timeline/CommentSection.svelte
@@ -42,6 +42,29 @@
         }));
     }
 
+    function mergeLoadedComments(
+        currentValue: TimelineCommentView[],
+        incomingValue: TimelineCommentView[],
+        nextAcceptedCommentId: string | null,
+    ) {
+        const mergedById = new Map(
+            currentValue.map((comment) => [comment.id, { ...comment }]),
+        );
+
+        for (const comment of incomingValue) {
+            mergedById.set(comment.id, { ...comment });
+        }
+
+        return syncAcceptedComment(
+            [...mergedById.values()].sort(
+                (left, right) =>
+                    new Date(left.createdAt).getTime() -
+                    new Date(right.createdAt).getTime(),
+            ),
+            nextAcceptedCommentId,
+        );
+    }
+
     function getCommentSignature(value: TimelineCommentView[]) {
         return value
             .map(
@@ -72,8 +95,9 @@
             showAll = showAll || defaultShowAll || hasFullComments;
 
             if (hasLoadedAllComments && !hasFullComments) {
-                currentComments = syncAcceptedComment(
+                currentComments = mergeLoadedComments(
                     currentComments,
+                    comments,
                     acceptedCommentId,
                 );
                 currentCommentCount = Math.max(commentCount, currentComments.length);

--- a/src/lib/components/timeline/TimelineComposer.svelte
+++ b/src/lib/components/timeline/TimelineComposer.svelte
@@ -1,37 +1,31 @@
 <script lang="ts">
-    import { api, currentUser, projects } from "$lib/stores/mock";
+    import { invalidate } from "$app/navigation";
+    import { page } from "$app/stores";
+    import { sessionUser } from "$lib/stores/session";
+    import type { TimelinePostType } from "$lib/shared/domain";
+    import { TIMELINE_INVALIDATION_KEY } from "$lib/shared/timeline";
     import { Rocket, HelpCircle, Trophy } from "lucide-svelte";
     import clsx from "clsx";
-    import type { PostType } from "$lib/stores/mock/data";
 
-    let type: PostType = "progress";
+    type TimelineComposerProject = {
+        id: string;
+        title: string;
+    };
+
+    export let projects: TimelineComposerProject[] = [];
+    export let invalidateKey: string = TIMELINE_INVALIDATION_KEY;
+
+    let type: TimelinePostType = "progress";
     let body = "";
     let title = "";
     let meta = { situation: "", problem: "", tried: "", environment: "" };
     let selectedProjectId = "";
+    let errorMessage = "";
+    let isSubmitting = false;
 
-    $: myProjects = $projects.filter((p) => p.ownerId === $currentUser?.id);
-    $: loginHref = `/login?next=${encodeURIComponent("/timeline")}`;
-
-    function handleSubmit() {
-        if (!body && type !== "question") return;
-        if (!$currentUser) return;
-
-        api.addPost({
-            authorId: $currentUser.id,
-            type,
-            title: type !== "progress" ? title : undefined,
-            body,
-            projectId: selectedProjectId || undefined,
-            questionMeta: type === "question" ? { ...meta } : undefined,
-            status: type === "question" ? "open" : undefined,
-        });
-
-        body = "";
-        title = "";
-        meta = { situation: "", problem: "", tried: "", environment: "" };
-        selectedProjectId = "";
-    }
+    $: loginHref = `/login?next=${encodeURIComponent(
+        `${$page.url.pathname}${$page.url.search}`,
+    )}`;
 
     const TYPES = [
         {
@@ -53,6 +47,49 @@
             color: "text-yellow-600 bg-yellow-50",
         },
     ] as const;
+
+    async function handleSubmit() {
+        if (!$sessionUser || isSubmitting) {
+            return;
+        }
+
+        errorMessage = "";
+        isSubmitting = true;
+
+        try {
+            const response = await fetch("/api/timeline", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    type,
+                    title: type !== "progress" ? title : undefined,
+                    body,
+                    projectId: selectedProjectId || undefined,
+                    questionMeta: type === "question" ? { ...meta } : undefined,
+                }),
+            });
+
+            const payload = (await response.json().catch(() => null)) as
+                | { message?: string }
+                | null;
+
+            if (!response.ok) {
+                errorMessage =
+                    payload?.message ?? "投稿の保存に失敗しました。";
+                return;
+            }
+
+            body = "";
+            title = "";
+            meta = { situation: "", problem: "", tried: "", environment: "" };
+            selectedProjectId = "";
+            await invalidate(invalidateKey);
+        } finally {
+            isSubmitting = false;
+        }
+    }
 </script>
 
 <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-6">
@@ -65,6 +102,7 @@
                         ? `${t.color} border-current ring-1 ring-inset`
                         : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50",
                 )}
+                disabled={isSubmitting}
                 on:click={() => (type = t.id)}
             >
                 <svelte:component this={t.icon} class="w-4 h-4" />
@@ -73,17 +111,17 @@
         {/each}
     </div>
 
-    {#if $currentUser}
+    {#if $sessionUser}
         <form on:submit|preventDefault={handleSubmit} class="space-y-3">
-            {#if myProjects.length > 0}
+            {#if projects.length > 0}
                 <div>
                     <select
                         bind:value={selectedProjectId}
                         class="text-sm border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 w-full md:w-auto"
                     >
                         <option value="">(プロジェクトに関連付ける)</option>
-                        {#each myProjects as p}
-                            <option value={p.id}>{p.title}</option>
+                        {#each projects as project}
+                            <option value={project.id}>{project.title}</option>
                         {/each}
                     </select>
                 </div>
@@ -186,12 +224,17 @@
                 ></textarea>
             {/if}
 
+            {#if errorMessage}
+                <p class="text-sm text-rose-600">{errorMessage}</p>
+            {/if}
+
             <div class="flex justify-end pt-2">
                 <button
                     type="submit"
-                    class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    disabled={isSubmitting}
+                    class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                 >
-                    投稿する
+                    {isSubmitting ? "送信中..." : "投稿する"}
                 </button>
             </div>
         </form>

--- a/src/lib/components/timeline/TimelinePostCard.svelte
+++ b/src/lib/components/timeline/TimelinePostCard.svelte
@@ -1,20 +1,25 @@
 <script lang="ts">
-    import { getUser, getProject, api, currentUser } from "$lib/stores/mock";
-    import type { TimelinePost } from "$lib/stores/mock/data";
     import ReactionBar from "$lib/components/shared/ReactionBar.svelte";
     import CommentSection from "./CommentSection.svelte";
-    import { CheckCircle, Clock } from "lucide-svelte";
+    import {
+        TIMELINE_INVALIDATION_KEY,
+        type TimelinePostView,
+    } from "$lib/shared/timeline";
+    import { CheckCircle, Clock, MessageSquareText } from "lucide-svelte";
     import { formatDistanceToNow } from "date-fns";
     import { ja } from "date-fns/locale";
 
-    export let post: TimelinePost;
+    export let post: TimelinePostView;
     export let compact = false;
+    export let showDetailLink = true;
+    export let showAllComments = false;
+    export let invalidateKey: string | null = TIMELINE_INVALIDATION_KEY;
 
-    $: author = getUser(post.authorId);
-    $: project = post.projectId ? getProject(post.projectId) : null;
-    $: isQuestion = post.type === "question";
-    $: isSolved = isQuestion && post.status === "solved";
-    $: isMyPost = $currentUser?.id === post.authorId;
+    const POST_TYPE_LABEL: Record<TimelinePostView["type"], string> = {
+        progress: "進捗",
+        question: "相談",
+        showcase: "見せびらかし",
+    };
 
     function timeAgo(dateStr: string) {
         try {
@@ -27,9 +32,10 @@
         }
     }
 
-    function markSolved(commentId: string) {
-        api.solveQuestion(post.id, commentId);
-    }
+    $: isQuestion = post.type === "question";
+    $: isSolved = isQuestion && post.status === "solved";
+    $: detailHref = `/timeline/${post.id}`;
+    $: commentViews = showAllComments ? post.comments : post.commentsPreview;
 </script>
 
 <div
@@ -37,32 +43,32 @@
         compact ? "p-4 mb-3" : "p-5 mb-4"
     }`}
 >
-    <!-- Header -->
     <div class="flex items-start justify-between mb-3">
         <div class="flex items-center gap-3">
             <img
-                src={$author?.avatarUrl}
+                src={post.author.avatarUrl ||
+                    `https://i.pravatar.cc/150?u=${encodeURIComponent(post.author.id)}`}
                 alt=""
                 class="w-10 h-10 rounded-full border border-gray-100"
             />
             <div>
-                <div class="flex items-center gap-2">
+                <div class="flex items-center gap-2 flex-wrap">
                     <a
-                        href={$author ? `/users/${$author.id}` : "#"}
+                        href={`/users/${post.author.id}`}
                         class="font-bold text-gray-900 hover:text-indigo-600"
                     >
-                        {$author?.name ?? "Unknown"}
+                        {post.author.displayName}
                     </a>
-                    {#if $project}
+                    {#if post.project}
                         <a
-                            href="/projects/{$project.id}"
-                            class="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 font-medium truncate max-w-[150px]"
+                            href={`/projects/${post.project.id}`}
+                            class="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 font-medium truncate max-w-[180px]"
                         >
-                            {$project.title}
+                            {post.project.title}
                         </a>
                     {/if}
                 </div>
-                <div class="flex items-center text-xs text-gray-500 gap-2">
+                <div class="flex items-center text-xs text-gray-500 gap-2 flex-wrap">
                     <span>{timeAgo(post.createdAt)}</span>
                     {#if isQuestion}
                         {#if isSolved}
@@ -83,15 +89,13 @@
             </div>
         </div>
 
-        <!-- Type Badge -->
         <div
             class="text-xs font-bold uppercase tracking-wider px-2 py-1 rounded text-gray-500 bg-gray-100"
         >
-            {post.type}
+            {POST_TYPE_LABEL[post.type]}
         </div>
     </div>
 
-    <!-- Content -->
     <div class="mb-4">
         {#if post.title}
             <h3 class="text-lg font-bold text-gray-900 mb-2">{post.title}</h3>
@@ -117,19 +121,36 @@
         <p class="text-gray-700 whitespace-pre-wrap">{post.body}</p>
     </div>
 
-    <!-- Reactions & Actions -->
     <div
-        class="flex items-center justify-between border-t border-gray-100 pt-3"
+        class="flex flex-col gap-3 border-t border-gray-100 pt-3 md:flex-row md:items-center md:justify-between"
     >
-        <ReactionBar targetId={post.id} targetType="post" />
+        <ReactionBar
+            targetId={post.id}
+            targetType="timeline_post"
+            reactions={post.reactions}
+            {invalidateKey}
+        />
+
+        {#if showDetailLink}
+            <a
+                href={detailHref}
+                class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500"
+            >
+                <MessageSquareText class="w-4 h-4" />
+                詳細を見る
+            </a>
+        {/if}
     </div>
 
-    <!-- Comments -->
     <CommentSection
         targetId={post.id}
-        targetType="post"
-        canSolve={isQuestion && !isSolved && isMyPost}
+        targetType="timeline_post"
+        comments={commentViews}
+        commentCount={post.commentCount}
+        canSolve={post.viewerCanSolve}
         acceptedCommentId={post.acceptedCommentId}
-        onSolve={markSolved}
+        defaultShowAll={showAllComments}
+        hasFullComments={showAllComments}
+        {invalidateKey}
     />
 </div>

--- a/src/lib/server/repositories/timeline.test.ts
+++ b/src/lib/server/repositories/timeline.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildReactionSummary,
+  canLinkProjectToTimelinePost,
+  canViewerAccessProject,
   isTimelinePostIncludedInFollowingFeed,
   selectTimelineCommentPreview,
   validateTimelineSolveRequest,
@@ -121,6 +123,50 @@ describe("timeline repository helpers", () => {
         ["u1"],
         ["p1"],
       ),
+    ).toBe(false);
+  });
+
+  it("draft プロジェクトは所有者だけ参照でき、タイムライン紐付けは公開済みのみ許可する", () => {
+    expect(
+      canViewerAccessProject(
+        {
+          ownerUserId: "u1",
+          status: "published",
+        },
+        null,
+      ),
+    ).toBe(true);
+
+    expect(
+      canViewerAccessProject(
+        {
+          ownerUserId: "u1",
+          status: "draft",
+        },
+        "u1",
+      ),
+    ).toBe(true);
+
+    expect(
+      canViewerAccessProject(
+        {
+          ownerUserId: "u1",
+          status: "draft",
+        },
+        "u2",
+      ),
+    ).toBe(false);
+
+    expect(
+      canLinkProjectToTimelinePost({
+        status: "published",
+      }),
+    ).toBe(true);
+
+    expect(
+      canLinkProjectToTimelinePost({
+        status: "draft",
+      }),
     ).toBe(false);
   });
 

--- a/src/lib/server/repositories/timeline.test.ts
+++ b/src/lib/server/repositories/timeline.test.ts
@@ -126,7 +126,7 @@ describe("timeline repository helpers", () => {
     ).toBe(false);
   });
 
-  it("draft プロジェクトは所有者だけ参照でき、タイムライン紐付けは公開済みのみ許可する", () => {
+  it("draft 以外のプロジェクトは参照でき、タイムライン紐付けは公開済みのみ許可する", () => {
     expect(
       canViewerAccessProject(
         {
@@ -156,6 +156,16 @@ describe("timeline repository helpers", () => {
         "u2",
       ),
     ).toBe(false);
+
+    expect(
+      canViewerAccessProject(
+        {
+          ownerUserId: "u1",
+          status: "archived",
+        },
+        "u2",
+      ),
+    ).toBe(true);
 
     expect(
       canLinkProjectToTimelinePost({

--- a/src/lib/server/repositories/timeline.test.ts
+++ b/src/lib/server/repositories/timeline.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReactionSummary,
+  isTimelinePostIncludedInFollowingFeed,
+  selectTimelineCommentPreview,
+  validateTimelineSolveRequest,
+} from "$lib/server/repositories/timeline";
+import {
+  createCommentInputSchema,
+  toggleReactionInputSchema,
+} from "$lib/shared/domain";
+
+describe("timeline repository helpers", () => {
+  it("リアクション集計で件数と自分の状態を返す", () => {
+    expect(
+      buildReactionSummary(
+        [
+          { kind: "clap", userId: "u1" },
+          { kind: "clap", userId: "u2" },
+          { kind: "fire", userId: "u3" },
+        ],
+        "u2",
+      ),
+    ).toEqual([
+      { kind: "clap", count: 2, reactedByMe: true },
+      { kind: "like", count: 0, reactedByMe: false },
+      { kind: "idea", count: 0, reactedByMe: false },
+      { kind: "fire", count: 1, reactedByMe: false },
+      { kind: "help", count: 0, reactedByMe: false },
+    ]);
+  });
+
+  it("コメント preview は末尾3件を返す", () => {
+    expect(
+      selectTimelineCommentPreview([
+        {
+          id: "c1",
+          targetId: "tp1",
+          targetType: "timeline_post",
+          body: "first",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          author: {
+            id: "u1",
+            displayName: "Alice",
+            avatarUrl: null,
+          },
+          isAccepted: false,
+        },
+        {
+          id: "c2",
+          targetId: "tp1",
+          targetType: "timeline_post",
+          body: "second",
+          createdAt: "2026-01-01T00:01:00.000Z",
+          author: {
+            id: "u2",
+            displayName: "Bob",
+            avatarUrl: null,
+          },
+          isAccepted: false,
+        },
+        {
+          id: "c3",
+          targetId: "tp1",
+          targetType: "timeline_post",
+          body: "third",
+          createdAt: "2026-01-01T00:02:00.000Z",
+          author: {
+            id: "u3",
+            displayName: "Carol",
+            avatarUrl: null,
+          },
+          isAccepted: false,
+        },
+        {
+          id: "c4",
+          targetId: "tp1",
+          targetType: "timeline_post",
+          body: "fourth",
+          createdAt: "2026-01-01T00:03:00.000Z",
+          author: {
+            id: "u4",
+            displayName: "Dave",
+            avatarUrl: null,
+          },
+          isAccepted: false,
+        },
+      ]).map((comment) => comment.id),
+    ).toEqual(["c2", "c3", "c4"]);
+  });
+
+  it("following feed はフォロー中ユーザーかフォロー中プロジェクト投稿を含める", () => {
+    expect(
+      isTimelinePostIncludedInFollowingFeed(
+        {
+          authorUserId: "u1",
+          projectId: null,
+        },
+        ["u1"],
+        [],
+      ),
+    ).toBe(true);
+
+    expect(
+      isTimelinePostIncludedInFollowingFeed(
+        {
+          authorUserId: "u9",
+          projectId: "p1",
+        },
+        [],
+        ["p1"],
+      ),
+    ).toBe(true);
+
+    expect(
+      isTimelinePostIncludedInFollowingFeed(
+        {
+          authorUserId: "u9",
+          projectId: "p9",
+        },
+        ["u1"],
+        ["p1"],
+      ),
+    ).toBe(false);
+  });
+
+  it("相談解決の検証は本人・質問投稿・関連コメントを要求する", () => {
+    expect(
+      validateTimelineSolveRequest({
+        acceptedComment: {
+          id: "c1",
+          targetId: "tp1",
+          targetType: "timeline_post",
+        },
+        post: {
+          id: "tp1",
+          authorUserId: "u1",
+          type: "progress",
+        },
+        viewerUserId: "u1",
+      }),
+    ).toEqual({
+      ok: false,
+      message: "相談投稿のみ解決済みにできます。",
+      status: 400,
+    });
+
+    expect(
+      validateTimelineSolveRequest({
+        acceptedComment: {
+          id: "c1",
+          targetId: "tp1",
+          targetType: "timeline_post",
+        },
+        post: {
+          id: "tp1",
+          authorUserId: "u1",
+          type: "question",
+        },
+        viewerUserId: "u2",
+      }),
+    ).toEqual({
+      ok: false,
+      message: "投稿者本人のみ解決済みにできます。",
+      status: 403,
+    });
+
+    expect(
+      validateTimelineSolveRequest({
+        acceptedComment: {
+          id: "c2",
+          targetId: "tp9",
+          targetType: "timeline_post",
+        },
+        post: {
+          id: "tp1",
+          authorUserId: "u1",
+          type: "question",
+        },
+        viewerUserId: "u1",
+      }),
+    ).toEqual({
+      ok: false,
+      message: "指定したコメントはこの相談投稿に紐づいていません。",
+      status: 400,
+    });
+
+    expect(
+      validateTimelineSolveRequest({
+        acceptedComment: {
+          id: "c1",
+          targetId: "tp1",
+          targetType: "timeline_post",
+        },
+        post: {
+          id: "tp1",
+          authorUserId: "u1",
+          type: "question",
+        },
+        viewerUserId: "u1",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("コメント payload は timeline_post / project / update のみ許可する", () => {
+    expect(
+      createCommentInputSchema.safeParse({
+        targetType: "timeline_post",
+        targetId: "tp1",
+        body: "hello",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      createCommentInputSchema.safeParse({
+        targetType: "comment",
+        targetId: "c1",
+        body: "hello",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("リアクション payload は定義済み kind のみ許可する", () => {
+    expect(
+      toggleReactionInputSchema.safeParse({
+        targetType: "timeline_post",
+        targetId: "tp1",
+        kind: "fire",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      toggleReactionInputSchema.safeParse({
+        targetType: "timeline_post",
+        targetId: "tp1",
+        kind: "rocket",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/lib/server/repositories/timeline.ts
+++ b/src/lib/server/repositories/timeline.ts
@@ -28,6 +28,7 @@ import {
 } from "$lib/shared/timeline";
 import { getProjectById } from "$lib/server/repositories/projects";
 
+type ProjectRecord = typeof projects.$inferSelect;
 type TimelinePostRecord = typeof timelinePosts.$inferSelect;
 type CommentRecord = typeof comments.$inferSelect;
 
@@ -56,6 +57,13 @@ type TimelineSolveValidationInput = {
   post: Pick<TimelinePostRecord, "authorUserId" | "id" | "type">;
   viewerUserId: string;
 };
+
+type ProjectVisibilityRecord = Pick<ProjectRecord, "ownerUserId" | "status">;
+
+type TimelineProjectRecord = Pick<
+  ProjectRecord,
+  "id" | "ownerUserId" | "status" | "title"
+>;
 
 export class TimelineRepositoryError extends Error {
   status: number;
@@ -89,6 +97,23 @@ function createTimelineAuthorFallback(userId: string) {
     displayName: "Unknown",
     avatarUrl: null,
   };
+}
+
+export function canViewerAccessProject(
+  project: ProjectVisibilityRecord | null,
+  viewerUserId?: string | null,
+) {
+  if (!project) {
+    return false;
+  }
+
+  return project.status === "published" || project.ownerUserId === viewerUserId;
+}
+
+export function canLinkProjectToTimelinePost(
+  project: Pick<ProjectRecord, "status"> | null,
+) {
+  return project?.status === "published";
 }
 
 export function buildReactionSummary(
@@ -264,6 +289,20 @@ function toCommentView(
   };
 }
 
+function toTimelineProjectSummary(
+  project: TimelineProjectRecord | null,
+  viewerUserId?: string | null,
+) {
+  if (!project || !canViewerAccessProject(project, viewerUserId)) {
+    return null;
+  }
+
+  return {
+    id: project.id,
+    title: project.title,
+  };
+}
+
 async function buildTimelinePostViews(
   postRows: TimelinePostRecord[],
   options: {
@@ -298,6 +337,8 @@ async function buildTimelinePostViews(
         ? db
             .select({
               id: projects.id,
+              ownerUserId: projects.ownerUserId,
+              status: projects.status,
               title: projects.title,
             })
             .from(projects)
@@ -393,12 +434,7 @@ async function buildTimelinePostViews(
         displayName: author.displayName,
         avatarUrl: author.avatarUrl,
       },
-      project: project
-        ? {
-            id: project.id,
-            title: project.title,
-          }
-        : null,
+      project: toTimelineProjectSummary(project, options.viewerUserId),
       commentCount: commentViews.length,
       commentsPreview: selectTimelineCommentPreview(commentViews),
       comments: options.includeFullComments ? commentViews : [],
@@ -426,6 +462,19 @@ async function getUpdateById(updateId: string) {
   return update ?? null;
 }
 
+async function getAccessibleProjectById(
+  projectId: string,
+  viewerUserId?: string | null,
+) {
+  const project = await getProjectById(projectId);
+
+  if (!canViewerAccessProject(project, viewerUserId)) {
+    return null;
+  }
+
+  return project;
+}
+
 export async function getTimelinePostById(postId: string) {
   const db = getDb();
   const [post] = await db
@@ -451,10 +500,11 @@ export async function getCommentById(commentId: string) {
 async function assertCommentTargetExists(
   targetType: CommentTargetType,
   targetId: string,
+  viewerUserId?: string | null,
 ) {
   switch (targetType) {
     case "project": {
-      const project = await getProjectById(targetId);
+      const project = await getAccessibleProjectById(targetId, viewerUserId);
 
       if (!project) {
         throw new TimelineRepositoryError(
@@ -468,7 +518,10 @@ async function assertCommentTargetExists(
     case "update": {
       const update = await getUpdateById(targetId);
 
-      if (!update) {
+      if (
+        !update ||
+        !(await getAccessibleProjectById(update.projectId, viewerUserId))
+      ) {
         throw new TimelineRepositoryError(
           404,
           "コメント対象の更新投稿が見つかりません。",
@@ -495,6 +548,7 @@ async function assertCommentTargetExists(
 async function assertReactionTargetExists(
   targetType: ReactionTargetType,
   targetId: string,
+  viewerUserId?: string | null,
 ) {
   switch (targetType) {
     case "comment": {
@@ -507,12 +561,17 @@ async function assertReactionTargetExists(
         );
       }
 
+      await assertCommentTargetExists(
+        comment.targetType,
+        comment.targetId,
+        viewerUserId,
+      );
       return;
     }
     case "project":
     case "update":
     case "timeline_post":
-      return assertCommentTargetExists(targetType, targetId);
+      return assertCommentTargetExists(targetType, targetId, viewerUserId);
   }
 }
 
@@ -601,6 +660,7 @@ export async function getTimelinePostViewById(
 export async function listCommentsForTarget(
   targetType: CommentTargetType,
   targetId: string,
+  viewerUserId?: string | null,
 ) {
   const db = getDb();
   let acceptedCommentId: string | null = null;
@@ -617,7 +677,7 @@ export async function listCommentsForTarget(
 
     acceptedCommentId = post.acceptedCommentId ?? null;
   } else {
-    await assertCommentTargetExists(targetType, targetId);
+    await assertCommentTargetExists(targetType, targetId, viewerUserId);
   }
 
   const rows = await db
@@ -646,7 +706,7 @@ export async function listReactionSummaryForTarget(
   targetId: string,
   viewerUserId?: string | null,
 ) {
-  await assertReactionTargetExists(targetType, targetId);
+  await assertReactionTargetExists(targetType, targetId, viewerUserId);
   const db = getDb();
   const rows = await db
     .select({
@@ -679,6 +739,13 @@ export async function createTimelinePost(
       throw new TimelineRepositoryError(
         404,
         "関連付けるプロジェクトが見つかりません。",
+      );
+    }
+
+    if (!canLinkProjectToTimelinePost(project)) {
+      throw new TimelineRepositoryError(
+        400,
+        "公開中のプロジェクトのみ関連付けできます。",
       );
     }
   }
@@ -717,7 +784,7 @@ export async function createComment(
   const commentId = crypto.randomUUID();
   const now = new Date();
 
-  await assertCommentTargetExists(input.targetType, input.targetId);
+  await assertCommentTargetExists(input.targetType, input.targetId, authorUserId);
 
   await db.insert(comments).values({
     id: commentId,
@@ -752,7 +819,7 @@ export async function addReaction(
 ) {
   const db = getDb();
 
-  await assertReactionTargetExists(targetType, targetId);
+  await assertReactionTargetExists(targetType, targetId, userId);
 
   await db
     .insert(reactions)
@@ -776,7 +843,7 @@ export async function removeReaction(
 ) {
   const db = getDb();
 
-  await assertReactionTargetExists(targetType, targetId);
+  await assertReactionTargetExists(targetType, targetId, userId);
 
   await db
     .delete(reactions)

--- a/src/lib/server/repositories/timeline.ts
+++ b/src/lib/server/repositories/timeline.ts
@@ -110,7 +110,7 @@ export function canViewerAccessProject(
     return false;
   }
 
-  return project.status === "published" || project.ownerUserId === viewerUserId;
+  return project.status !== "draft" || project.ownerUserId === viewerUserId;
 }
 
 export function canLinkProjectToTimelinePost(

--- a/src/lib/server/repositories/timeline.ts
+++ b/src/lib/server/repositories/timeline.ts
@@ -26,7 +26,10 @@ import {
   type TimelineReactionSummary,
   type TimelineScope,
 } from "$lib/shared/timeline";
-import { getProjectById } from "$lib/server/repositories/projects";
+import {
+  getProjectById,
+  isProjectMember,
+} from "$lib/server/repositories/projects";
 
 type ProjectRecord = typeof projects.$inferSelect;
 type TimelinePostRecord = typeof timelinePosts.$inferSelect;
@@ -748,6 +751,13 @@ export async function createTimelinePost(
         "公開中のプロジェクトのみ関連付けできます。",
       );
     }
+
+    if (!(await isProjectMember(input.projectId, authorUserId))) {
+      throw new TimelineRepositoryError(
+        403,
+        "関連付けるには対象プロジェクトのメンバーである必要があります。",
+      );
+    }
   }
 
   await db.insert(timelinePosts).values({
@@ -784,7 +794,11 @@ export async function createComment(
   const commentId = crypto.randomUUID();
   const now = new Date();
 
-  await assertCommentTargetExists(input.targetType, input.targetId, authorUserId);
+  await assertCommentTargetExists(
+    input.targetType,
+    input.targetId,
+    authorUserId,
+  );
 
   await db.insert(comments).values({
     id: commentId,
@@ -799,6 +813,7 @@ export async function createComment(
   const [comment] = await listCommentsForTarget(
     input.targetType,
     input.targetId,
+    authorUserId,
   ).then((rows) => rows.filter((row) => row.id === commentId));
 
   if (!comment) {

--- a/src/lib/server/repositories/timeline.ts
+++ b/src/lib/server/repositories/timeline.ts
@@ -1,7 +1,430 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray, or } from "drizzle-orm";
 import { getDb } from "$lib/server/db";
-import { comments, timelinePosts } from "$lib/server/db/schema";
-import type { CommentTargetType } from "$lib/shared/domain";
+import {
+  comments,
+  follows,
+  projects,
+  reactions,
+  timelinePosts,
+  updates,
+  users,
+} from "$lib/server/db/schema";
+import type {
+  CommentTargetType,
+  CreateCommentInput,
+  CreateTimelinePostInput,
+  ReactionKind,
+  ReactionTargetType,
+  TimelinePostStatus,
+  TimelinePostType,
+} from "$lib/shared/domain";
+import {
+  createEmptyTimelineReactionSummary,
+  TIMELINE_COMMENT_PREVIEW_LIMIT,
+  type TimelineCommentView,
+  type TimelinePostView,
+  type TimelineReactionSummary,
+  type TimelineScope,
+} from "$lib/shared/timeline";
+import { getProjectById } from "$lib/server/repositories/projects";
+
+type TimelinePostRecord = typeof timelinePosts.$inferSelect;
+type CommentRecord = typeof comments.$inferSelect;
+
+type TimelineListOptions = {
+  scope?: TimelineScope;
+  viewerUserId?: string | null;
+  limit?: number;
+  authorUserId?: string;
+  types?: TimelinePostType[];
+  statuses?: TimelinePostStatus[];
+  includeFullComments?: boolean;
+};
+
+type ReactionRecordLike = {
+  kind: ReactionKind;
+  userId: string;
+};
+
+type FollowingTargets = {
+  projectIds: string[];
+  userIds: string[];
+};
+
+type TimelineSolveValidationInput = {
+  acceptedComment: Pick<CommentRecord, "id" | "targetId" | "targetType"> | null;
+  post: Pick<TimelinePostRecord, "authorUserId" | "id" | "type">;
+  viewerUserId: string;
+};
+
+export class TimelineRepositoryError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "TimelineRepositoryError";
+    this.status = status;
+  }
+}
+
+function getWhereClause(
+  conditions: Array<
+    ReturnType<typeof eq> | ReturnType<typeof inArray> | ReturnType<typeof or>
+  >,
+) {
+  if (conditions.length === 0) {
+    return undefined;
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return and(...conditions);
+}
+
+function createTimelineAuthorFallback(userId: string) {
+  return {
+    id: userId,
+    displayName: "Unknown",
+    avatarUrl: null,
+  };
+}
+
+export function buildReactionSummary(
+  reactionRows: ReactionRecordLike[],
+  viewerUserId?: string | null,
+) {
+  const summary = createEmptyTimelineReactionSummary();
+  const summaryMap = new Map(summary.map((item) => [item.kind, item]));
+
+  for (const row of reactionRows) {
+    const current = summaryMap.get(row.kind);
+
+    if (!current) {
+      continue;
+    }
+
+    current.count += 1;
+
+    if (viewerUserId && row.userId === viewerUserId) {
+      current.reactedByMe = true;
+    }
+  }
+
+  return summary;
+}
+
+export function selectTimelineCommentPreview(
+  commentViews: TimelineCommentView[],
+  limit = TIMELINE_COMMENT_PREVIEW_LIMIT,
+) {
+  if (commentViews.length <= limit) {
+    return [...commentViews];
+  }
+
+  return commentViews.slice(commentViews.length - limit);
+}
+
+export function isTimelinePostIncludedInFollowingFeed(
+  post: Pick<TimelinePostRecord, "authorUserId" | "projectId">,
+  followedUserIds: string[],
+  followedProjectIds: string[],
+) {
+  if (followedUserIds.includes(post.authorUserId)) {
+    return true;
+  }
+
+  return Boolean(post.projectId && followedProjectIds.includes(post.projectId));
+}
+
+export function validateTimelineSolveRequest(
+  input: TimelineSolveValidationInput,
+) {
+  if (input.post.type !== "question") {
+    return {
+      ok: false as const,
+      message: "相談投稿のみ解決済みにできます。",
+      status: 400,
+    };
+  }
+
+  if (input.post.authorUserId !== input.viewerUserId) {
+    return {
+      ok: false as const,
+      message: "投稿者本人のみ解決済みにできます。",
+      status: 403,
+    };
+  }
+
+  if (
+    !input.acceptedComment ||
+    input.acceptedComment.targetType !== "timeline_post" ||
+    input.acceptedComment.targetId !== input.post.id
+  ) {
+    return {
+      ok: false as const,
+      message: "指定したコメントはこの相談投稿に紐づいていません。",
+      status: 400,
+    };
+  }
+
+  return {
+    ok: true as const,
+  };
+}
+
+function assertTimelineResult(
+  result:
+    | { ok: true }
+    | {
+        ok: false;
+        message: string;
+        status: number;
+      },
+) {
+  if (!result.ok) {
+    throw new TimelineRepositoryError(result.status, result.message);
+  }
+}
+
+async function listFollowingTargets(userId: string): Promise<FollowingTargets> {
+  const db = getDb();
+  const followRows = await db
+    .select({
+      targetId: follows.targetId,
+      targetType: follows.targetType,
+    })
+    .from(follows)
+    .where(eq(follows.followerUserId, userId));
+
+  const projectIds: string[] = [];
+  const userIds: string[] = [];
+
+  for (const followRow of followRows) {
+    if (followRow.targetType === "project") {
+      projectIds.push(followRow.targetId);
+      continue;
+    }
+
+    if (followRow.targetType === "user") {
+      userIds.push(followRow.targetId);
+    }
+  }
+
+  return {
+    projectIds,
+    userIds,
+  };
+}
+
+function getFollowingFeedCondition(targets: FollowingTargets) {
+  const conditions = [];
+
+  if (targets.userIds.length > 0) {
+    conditions.push(inArray(timelinePosts.authorUserId, targets.userIds));
+  }
+
+  if (targets.projectIds.length > 0) {
+    conditions.push(inArray(timelinePosts.projectId, targets.projectIds));
+  }
+
+  if (conditions.length === 0) {
+    return null;
+  }
+
+  return conditions.length === 1 ? conditions[0] : or(...conditions);
+}
+
+function toCommentView(
+  row: {
+    authorAvatarUrl: string | null;
+    authorDisplayName: string;
+    authorId: string;
+    body: string;
+    createdAt: Date;
+    id: string;
+    targetId: string;
+    targetType: CommentTargetType;
+  },
+  acceptedCommentId: string | null,
+): TimelineCommentView {
+  return {
+    id: row.id,
+    targetId: row.targetId,
+    targetType: row.targetType,
+    body: row.body,
+    createdAt: row.createdAt.toISOString(),
+    author: {
+      id: row.authorId,
+      displayName: row.authorDisplayName,
+      avatarUrl: row.authorAvatarUrl,
+    },
+    isAccepted: row.id === acceptedCommentId,
+  };
+}
+
+async function buildTimelinePostViews(
+  postRows: TimelinePostRecord[],
+  options: {
+    includeFullComments: boolean;
+    viewerUserId?: string | null;
+  },
+) {
+  if (postRows.length === 0) {
+    return [];
+  }
+
+  const db = getDb();
+  const postIds = postRows.map((post) => post.id);
+  const authorUserIds = [...new Set(postRows.map((post) => post.authorUserId))];
+  const projectIds = [
+    ...new Set(
+      postRows.flatMap((post) => (post.projectId ? [post.projectId] : [])),
+    ),
+  ];
+
+  const [authorRows, projectRows, commentRows, reactionRows] =
+    await Promise.all([
+      db
+        .select({
+          avatarUrl: users.avatarUrl,
+          displayName: users.displayName,
+          id: users.id,
+        })
+        .from(users)
+        .where(inArray(users.id, authorUserIds)),
+      projectIds.length > 0
+        ? db
+            .select({
+              id: projects.id,
+              title: projects.title,
+            })
+            .from(projects)
+            .where(inArray(projects.id, projectIds))
+        : Promise.resolve([]),
+      db
+        .select({
+          authorAvatarUrl: users.avatarUrl,
+          authorDisplayName: users.displayName,
+          authorId: users.id,
+          body: comments.body,
+          createdAt: comments.createdAt,
+          id: comments.id,
+          targetId: comments.targetId,
+          targetType: comments.targetType,
+        })
+        .from(comments)
+        .innerJoin(users, eq(comments.authorUserId, users.id))
+        .where(
+          and(
+            eq(comments.targetType, "timeline_post"),
+            inArray(comments.targetId, postIds),
+          ),
+        )
+        .orderBy(comments.createdAt),
+      db
+        .select({
+          kind: reactions.kind,
+          targetId: reactions.targetId,
+          userId: reactions.userId,
+        })
+        .from(reactions)
+        .where(
+          and(
+            eq(reactions.targetType, "timeline_post"),
+            inArray(reactions.targetId, postIds),
+          ),
+        ),
+    ]);
+
+  const authorMap = new Map(authorRows.map((author) => [author.id, author]));
+  const projectMap = new Map(
+    projectRows.map((project) => [project.id, project]),
+  );
+  const commentsByPostId = new Map<string, TimelineCommentView[]>();
+  const reactionsByPostId = new Map<string, ReactionRecordLike[]>();
+
+  const acceptedCommentIdByPostId = new Map(
+    postRows.map((post) => [post.id, post.acceptedCommentId ?? null]),
+  );
+
+  for (const commentRow of commentRows) {
+    const current = commentsByPostId.get(commentRow.targetId) ?? [];
+    current.push(
+      toCommentView(
+        commentRow,
+        acceptedCommentIdByPostId.get(commentRow.targetId) ?? null,
+      ),
+    );
+    commentsByPostId.set(commentRow.targetId, current);
+  }
+
+  for (const reactionRow of reactionRows) {
+    const current = reactionsByPostId.get(reactionRow.targetId) ?? [];
+    current.push({
+      kind: reactionRow.kind,
+      userId: reactionRow.userId,
+    });
+    reactionsByPostId.set(reactionRow.targetId, current);
+  }
+
+  return postRows.map<TimelinePostView>((post) => {
+    const commentViews = commentsByPostId.get(post.id) ?? [];
+    const author =
+      authorMap.get(post.authorUserId) ??
+      createTimelineAuthorFallback(post.authorUserId);
+    const project = post.projectId
+      ? (projectMap.get(post.projectId) ?? null)
+      : null;
+
+    return {
+      id: post.id,
+      type: post.type,
+      title: post.title ?? null,
+      body: post.body ?? "",
+      status: post.status,
+      questionMeta: post.questionMeta ?? null,
+      createdAt: post.createdAt.toISOString(),
+      updatedAt: post.updatedAt.toISOString(),
+      acceptedCommentId: post.acceptedCommentId ?? null,
+      author: {
+        id: author.id,
+        displayName: author.displayName,
+        avatarUrl: author.avatarUrl,
+      },
+      project: project
+        ? {
+            id: project.id,
+            title: project.title,
+          }
+        : null,
+      commentCount: commentViews.length,
+      commentsPreview: selectTimelineCommentPreview(commentViews),
+      comments: options.includeFullComments ? commentViews : [],
+      reactions: buildReactionSummary(
+        reactionsByPostId.get(post.id) ?? [],
+        options.viewerUserId,
+      ),
+      viewerCanSolve:
+        Boolean(options.viewerUserId) &&
+        post.type === "question" &&
+        post.status === "open" &&
+        post.authorUserId === options.viewerUserId,
+    };
+  });
+}
+
+async function getUpdateById(updateId: string) {
+  const db = getDb();
+  const [update] = await db
+    .select()
+    .from(updates)
+    .where(eq(updates.id, updateId))
+    .limit(1);
+
+  return update ?? null;
+}
 
 export async function getTimelinePostById(postId: string) {
   const db = getDb();
@@ -12,17 +435,6 @@ export async function getTimelinePostById(postId: string) {
     .limit(1);
 
   return post ?? null;
-}
-
-export async function listRecentTimelinePosts(limit = 20) {
-  const db = getDb();
-
-  return db
-    .select()
-    .from(timelinePosts)
-    .where(eq(timelinePosts.isHidden, false))
-    .orderBy(desc(timelinePosts.createdAt))
-    .limit(limit);
 }
 
 export async function getCommentById(commentId: string) {
@@ -36,17 +448,393 @@ export async function getCommentById(commentId: string) {
   return comment ?? null;
 }
 
+async function assertCommentTargetExists(
+  targetType: CommentTargetType,
+  targetId: string,
+) {
+  switch (targetType) {
+    case "project": {
+      const project = await getProjectById(targetId);
+
+      if (!project) {
+        throw new TimelineRepositoryError(
+          404,
+          "コメント対象のプロジェクトが見つかりません。",
+        );
+      }
+
+      return;
+    }
+    case "update": {
+      const update = await getUpdateById(targetId);
+
+      if (!update) {
+        throw new TimelineRepositoryError(
+          404,
+          "コメント対象の更新投稿が見つかりません。",
+        );
+      }
+
+      return;
+    }
+    case "timeline_post": {
+      const post = await getTimelinePostById(targetId);
+
+      if (!post || post.isHidden) {
+        throw new TimelineRepositoryError(
+          404,
+          "コメント対象のタイムライン投稿が見つかりません。",
+        );
+      }
+
+      return;
+    }
+  }
+}
+
+async function assertReactionTargetExists(
+  targetType: ReactionTargetType,
+  targetId: string,
+) {
+  switch (targetType) {
+    case "comment": {
+      const comment = await getCommentById(targetId);
+
+      if (!comment) {
+        throw new TimelineRepositoryError(
+          404,
+          "リアクション対象のコメントが見つかりません。",
+        );
+      }
+
+      return;
+    }
+    case "project":
+    case "update":
+    case "timeline_post":
+      return assertCommentTargetExists(targetType, targetId);
+  }
+}
+
+export async function listTimelinePosts(options: TimelineListOptions = {}) {
+  const db = getDb();
+  const scope = options.scope ?? "global";
+  const conditions = [eq(timelinePosts.isHidden, false)];
+  let followingTargets: FollowingTargets | null = null;
+
+  if (options.authorUserId) {
+    conditions.push(eq(timelinePosts.authorUserId, options.authorUserId));
+  }
+
+  if (options.types && options.types.length > 0) {
+    conditions.push(inArray(timelinePosts.type, options.types));
+  }
+
+  if (options.statuses && options.statuses.length > 0) {
+    conditions.push(inArray(timelinePosts.status, options.statuses));
+  }
+
+  if (scope === "following") {
+    if (!options.viewerUserId) {
+      return [];
+    }
+
+    followingTargets = await listFollowingTargets(options.viewerUserId);
+    const followingCondition = getFollowingFeedCondition(followingTargets);
+
+    if (!followingCondition) {
+      return [];
+    }
+
+    conditions.push(followingCondition);
+  }
+
+  const whereClause = getWhereClause(conditions);
+  const postRows = whereClause
+    ? await db
+        .select()
+        .from(timelinePosts)
+        .where(whereClause)
+        .orderBy(desc(timelinePosts.createdAt))
+        .limit(options.limit ?? 20)
+    : await db
+        .select()
+        .from(timelinePosts)
+        .orderBy(desc(timelinePosts.createdAt))
+        .limit(options.limit ?? 20);
+
+  const filteredRows =
+    scope === "following" && followingTargets
+      ? postRows.filter((post) =>
+          isTimelinePostIncludedInFollowingFeed(
+            post,
+            followingTargets.userIds,
+            followingTargets.projectIds,
+          ),
+        )
+      : postRows;
+
+  return buildTimelinePostViews(filteredRows, {
+    includeFullComments: options.includeFullComments ?? false,
+    viewerUserId: options.viewerUserId,
+  });
+}
+
+export async function getTimelinePostViewById(
+  postId: string,
+  viewerUserId?: string | null,
+) {
+  const post = await getTimelinePostById(postId);
+
+  if (!post || post.isHidden) {
+    return null;
+  }
+
+  const [view] = await buildTimelinePostViews([post], {
+    includeFullComments: true,
+    viewerUserId,
+  });
+
+  return view ?? null;
+}
+
 export async function listCommentsForTarget(
   targetType: CommentTargetType,
   targetId: string,
 ) {
   const db = getDb();
+  let acceptedCommentId: string | null = null;
 
-  return db
-    .select()
+  if (targetType === "timeline_post") {
+    const post = await getTimelinePostById(targetId);
+
+    if (!post || post.isHidden) {
+      throw new TimelineRepositoryError(
+        404,
+        "コメント対象のタイムライン投稿が見つかりません。",
+      );
+    }
+
+    acceptedCommentId = post.acceptedCommentId ?? null;
+  } else {
+    await assertCommentTargetExists(targetType, targetId);
+  }
+
+  const rows = await db
+    .select({
+      authorAvatarUrl: users.avatarUrl,
+      authorDisplayName: users.displayName,
+      authorId: users.id,
+      body: comments.body,
+      createdAt: comments.createdAt,
+      id: comments.id,
+      targetId: comments.targetId,
+      targetType: comments.targetType,
+    })
     .from(comments)
+    .innerJoin(users, eq(comments.authorUserId, users.id))
     .where(
       and(eq(comments.targetType, targetType), eq(comments.targetId, targetId)),
     )
     .orderBy(comments.createdAt);
+
+  return rows.map((row) => toCommentView(row, acceptedCommentId));
+}
+
+export async function listReactionSummaryForTarget(
+  targetType: ReactionTargetType,
+  targetId: string,
+  viewerUserId?: string | null,
+) {
+  await assertReactionTargetExists(targetType, targetId);
+  const db = getDb();
+  const rows = await db
+    .select({
+      kind: reactions.kind,
+      userId: reactions.userId,
+    })
+    .from(reactions)
+    .where(
+      and(
+        eq(reactions.targetType, targetType),
+        eq(reactions.targetId, targetId),
+      ),
+    );
+
+  return buildReactionSummary(rows, viewerUserId);
+}
+
+export async function createTimelinePost(
+  authorUserId: string,
+  input: CreateTimelinePostInput,
+) {
+  const db = getDb();
+  const postId = crypto.randomUUID();
+  const now = new Date();
+
+  if (input.projectId) {
+    const project = await getProjectById(input.projectId);
+
+    if (!project) {
+      throw new TimelineRepositoryError(
+        404,
+        "関連付けるプロジェクトが見つかりません。",
+      );
+    }
+  }
+
+  await db.insert(timelinePosts).values({
+    id: postId,
+    authorUserId,
+    type: input.type,
+    title: input.title ?? null,
+    body: input.body ?? null,
+    projectId: input.projectId ?? null,
+    eventId: input.eventId ?? null,
+    questionMeta: input.questionMeta ?? null,
+    status: input.type === "question" ? "open" : "open",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const post = await getTimelinePostViewById(postId, authorUserId);
+
+  if (!post) {
+    throw new TimelineRepositoryError(
+      500,
+      "タイムライン投稿の作成後に読み込みできませんでした。",
+    );
+  }
+
+  return post;
+}
+
+export async function createComment(
+  authorUserId: string,
+  input: CreateCommentInput,
+) {
+  const db = getDb();
+  const commentId = crypto.randomUUID();
+  const now = new Date();
+
+  await assertCommentTargetExists(input.targetType, input.targetId);
+
+  await db.insert(comments).values({
+    id: commentId,
+    targetType: input.targetType,
+    targetId: input.targetId,
+    authorUserId,
+    body: input.body,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const [comment] = await listCommentsForTarget(
+    input.targetType,
+    input.targetId,
+  ).then((rows) => rows.filter((row) => row.id === commentId));
+
+  if (!comment) {
+    throw new TimelineRepositoryError(
+      500,
+      "コメント作成後に再取得できませんでした。",
+    );
+  }
+
+  return comment;
+}
+
+export async function addReaction(
+  userId: string,
+  targetType: ReactionTargetType,
+  targetId: string,
+  kind: ReactionKind,
+) {
+  const db = getDb();
+
+  await assertReactionTargetExists(targetType, targetId);
+
+  await db
+    .insert(reactions)
+    .values({
+      id: crypto.randomUUID(),
+      targetType,
+      targetId,
+      userId,
+      kind,
+    })
+    .onConflictDoNothing();
+
+  return listReactionSummaryForTarget(targetType, targetId, userId);
+}
+
+export async function removeReaction(
+  userId: string,
+  targetType: ReactionTargetType,
+  targetId: string,
+  kind: ReactionKind,
+) {
+  const db = getDb();
+
+  await assertReactionTargetExists(targetType, targetId);
+
+  await db
+    .delete(reactions)
+    .where(
+      and(
+        eq(reactions.targetType, targetType),
+        eq(reactions.targetId, targetId),
+        eq(reactions.userId, userId),
+        eq(reactions.kind, kind),
+      ),
+    );
+
+  return listReactionSummaryForTarget(targetType, targetId, userId);
+}
+
+export async function solveTimelinePost(
+  postId: string,
+  viewerUserId: string,
+  acceptedCommentId: string,
+) {
+  const db = getDb();
+  const [post, acceptedComment] = await Promise.all([
+    getTimelinePostById(postId),
+    getCommentById(acceptedCommentId),
+  ]);
+
+  if (!post || post.isHidden) {
+    throw new TimelineRepositoryError(
+      404,
+      "対象のタイムライン投稿が見つかりません。",
+    );
+  }
+
+  assertTimelineResult(
+    validateTimelineSolveRequest({
+      acceptedComment,
+      post,
+      viewerUserId,
+    }),
+  );
+
+  await db
+    .update(timelinePosts)
+    .set({
+      acceptedCommentId,
+      status: "solved",
+      updatedAt: new Date(),
+    })
+    .where(eq(timelinePosts.id, postId));
+
+  const nextPost = await getTimelinePostViewById(postId, viewerUserId);
+
+  if (!nextPost) {
+    throw new TimelineRepositoryError(
+      500,
+      "解決済み更新後のタイムライン投稿を取得できませんでした。",
+    );
+  }
+
+  return nextPost;
 }

--- a/src/lib/shared/timeline.ts
+++ b/src/lib/shared/timeline.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import {
+  entityIdSchema,
+  REACTION_KIND_VALUES,
+  type CommentTargetType,
+  type ReactionKind,
+  type TimelinePostStatus,
+  type TimelinePostType,
+  type TimelineQuestionMeta,
+} from "$lib/shared/domain";
+
+export const TIMELINE_SCOPE_VALUES = ["global", "following"] as const;
+export const timelineScopeSchema = z.enum(TIMELINE_SCOPE_VALUES);
+export type TimelineScope = (typeof TIMELINE_SCOPE_VALUES)[number];
+
+export const solveTimelinePostInputSchema = z.object({
+  acceptedCommentId: entityIdSchema,
+});
+export type SolveTimelinePostInput = z.infer<
+  typeof solveTimelinePostInputSchema
+>;
+
+export const TIMELINE_INVALIDATION_KEY = "app:timeline";
+export const TIMELINE_COMMENT_PREVIEW_LIMIT = 3;
+
+export type TimelineAuthorView = {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+};
+
+export type TimelineProjectSummary = {
+  id: string;
+  title: string;
+};
+
+export type TimelineReactionSummary = {
+  kind: ReactionKind;
+  count: number;
+  reactedByMe: boolean;
+};
+
+export type TimelineCommentView = {
+  id: string;
+  targetId: string;
+  targetType: CommentTargetType;
+  body: string;
+  createdAt: string;
+  author: TimelineAuthorView;
+  isAccepted: boolean;
+};
+
+export type TimelinePostView = {
+  id: string;
+  type: TimelinePostType;
+  title: string | null;
+  body: string;
+  status: TimelinePostStatus;
+  questionMeta: TimelineQuestionMeta | null;
+  createdAt: string;
+  updatedAt: string;
+  acceptedCommentId: string | null;
+  author: TimelineAuthorView;
+  project: TimelineProjectSummary | null;
+  commentCount: number;
+  commentsPreview: TimelineCommentView[];
+  comments: TimelineCommentView[];
+  reactions: TimelineReactionSummary[];
+  viewerCanSolve: boolean;
+};
+
+export function parseTimelineScope(
+  value: string | null | undefined,
+): TimelineScope {
+  const parsed = timelineScopeSchema.safeParse(value);
+  return parsed.success ? parsed.data : "global";
+}
+
+export function createEmptyTimelineReactionSummary() {
+  return REACTION_KIND_VALUES.map((kind) => ({
+    kind,
+    count: 0,
+    reactedByMe: false as boolean,
+  })) satisfies TimelineReactionSummary[];
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,28 +1,24 @@
 import type { PageServerLoad } from "./$types";
-import { requireOnboarded } from "$lib/server/auth/guards";
 import { listProjects } from "$lib/server/repositories/projects";
 import { listTimelinePosts } from "$lib/server/repositories/timeline";
 import { TIMELINE_INVALIDATION_KEY } from "$lib/shared/timeline";
 
 export const load: PageServerLoad = async (event) => {
-  const user = requireOnboarded(event);
   event.depends(TIMELINE_INVALIDATION_KEY);
 
-  const [myProjects, myUnresolvedQuestions] = await Promise.all([
-    listProjects({
-      ownerUserId: user.id,
-    }),
+  const [recentPosts, recentProjects] = await Promise.all([
     listTimelinePosts({
-      viewerUserId: user.id,
-      authorUserId: user.id,
-      types: ["question"],
-      statuses: ["open"],
-      limit: 10,
+      viewerUserId: event.locals.user?.id,
+      limit: 5,
+    }),
+    listProjects({
+      statuses: ["published"],
+      limit: 3,
     }),
   ]);
 
   return {
-    myProjects,
-    myUnresolvedQuestions,
+    recentPosts,
+    recentProjects,
   };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,48 +1,50 @@
 <script lang="ts">
-    import {
-        timelinePosts,
-        projects,
-        userPreferences,
-        currentUser,
-    } from "$lib/stores/mock";
-    import TimelinePostCard from "$lib/components/timeline/TimelinePostCard.svelte";
+    import { page } from "$app/stores";
     import ProjectCard from "$lib/components/projects/ProjectCard.svelte";
-    import { Rocket, Plus, Search } from "lucide-svelte";
+    import TimelinePostCard from "$lib/components/timeline/TimelinePostCard.svelte";
+    import type {
+        ProjectHelpType,
+        ProjectStage,
+        ProjectStatus,
+    } from "$lib/shared/domain";
+    import type { TimelinePostView } from "$lib/shared/timeline";
+    import { Rocket, Search } from "lucide-svelte";
 
-    // Sort logic based on prefs
-    $: myPrefs = $userPreferences.find((p) => p.userId === $currentUser?.id);
-    $: focusModes = myPrefs?.focusModes || [
-        "post",
-        "support",
-        "collab",
-        "event",
-    ];
+    export let data: {
+        recentPosts: TimelinePostView[];
+        recentProjects: Array<{
+            id: string;
+            ownerId: string;
+            ownerName: string | null;
+            ownerAvatarUrl: string | null;
+            title: string;
+            oneLiner: string;
+            problemStatement: string;
+            projectStage: ProjectStage | null;
+            helpTypes: ProjectHelpType[];
+            helpRequest: string;
+            highlights: string[];
+            nextMilestone: string;
+            feedbackRequest: string;
+            backgroundNote: string;
+            publicUrl?: string;
+            repoUrl?: string;
+            demoUrl?: string;
+            tags: string[];
+            images: string[];
+            status: ProjectStatus;
+            createdAt: string;
+            updatedAt: string;
+        }>;
+    };
 
-    // Latest timeline
-    $: recentPosts = [...$timelinePosts]
-        .sort(
-            (a, b) =>
-                new Date(b.createdAt).getTime() -
-                new Date(a.createdAt).getTime(),
-        )
-        .slice(0, 5);
+    const defaultFocusModes = ["post", "support", "collab", "event"];
 
-    // Latest projects
-    $: recentProjects = [...$projects]
-        .sort(
-            (a, b) =>
-                new Date(b.updatedAt).getTime() -
-                new Date(a.updatedAt).getTime(),
-        )
-        .slice(0, 3);
-
-    // Dynamic Section Ordering
-    // If 'post' is primary, show Timeline first. If 'support', show Projects first.
-    // For MVP, just show sections.
+    $: focusModes = $page.data.preferences?.focusModes ?? defaultFocusModes;
+    $: hasPreferences = Boolean($page.data.preferences);
 </script>
 
 <div class="space-y-12">
-    <!-- Hero / CTA -->
     <section
         class="text-center py-10 px-4 bg-gradient-to-r from-indigo-600 to-purple-600 rounded-2xl text-white shadow-xl"
     >
@@ -72,8 +74,7 @@
         </div>
     </section>
 
-    <!-- My Focus -->
-    {#if myPrefs}
+    {#if hasPreferences}
         <div class="flex items-center justify-between">
             <h2 class="text-xl font-bold text-gray-800">
                 あなたの現在のモード
@@ -83,20 +84,18 @@
                 class="text-sm text-indigo-600 hover:underline">変更する</a
             >
         </div>
-        <div class="flex gap-2 -mt-8 mb-8">
-            {#each focusModes as m}
+        <div class="flex gap-2 -mt-8 mb-8 flex-wrap">
+            {#each focusModes as mode}
                 <span
                     class="px-3 py-1 bg-indigo-50 text-indigo-700 rounded-full text-sm font-medium border border-indigo-100 uppercase"
-                    >{m}</span
+                    >{mode}</span
                 >
             {/each}
         </div>
     {/if}
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <!-- Main Feed -->
         <div class="lg:col-span-2 space-y-8">
-            <!-- Latest Posts -->
             <section>
                 <div class="flex items-center justify-between mb-4">
                     <h2
@@ -111,17 +110,24 @@
                         >もっと見る &rarr;</a
                     >
                 </div>
-                <div class="space-y-4">
-                    {#each recentPosts as post (post.id)}
-                        <TimelinePostCard {post} />
-                    {/each}
-                </div>
+
+                {#if data.recentPosts.length > 0}
+                    <div class="space-y-4">
+                        {#each data.recentPosts as post (post.id)}
+                            <TimelinePostCard {post} />
+                        {/each}
+                    </div>
+                {:else}
+                    <div
+                        class="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center text-gray-500"
+                    >
+                        まだ投稿がありません。最初の投稿をしてみましょう。
+                    </div>
+                {/if}
             </section>
         </div>
 
-        <!-- Right Column -->
         <div class="space-y-8">
-            <!-- New Projects -->
             <section>
                 <div class="flex items-center justify-between mb-4">
                     <h2 class="text-xl font-bold text-gray-900">
@@ -133,11 +139,20 @@
                         >一覧 &rarr;</a
                     >
                 </div>
-                <div class="space-y-4">
-                    {#each recentProjects as project (project.id)}
-                        <ProjectCard {project} />
-                    {/each}
-                </div>
+
+                {#if data.recentProjects.length > 0}
+                    <div class="space-y-4">
+                        {#each data.recentProjects as project (project.id)}
+                            <ProjectCard {project} />
+                        {/each}
+                    </div>
+                {:else}
+                    <div
+                        class="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center text-gray-500"
+                    >
+                        まだ公開プロジェクトがありません。
+                    </div>
+                {/if}
             </section>
         </div>
     </div>

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -1,0 +1,82 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import { z } from "zod";
+import {
+  createComment,
+  listCommentsForTarget,
+  TimelineRepositoryError,
+} from "$lib/server/repositories/timeline";
+import {
+  commentTargetTypeSchema,
+  createCommentInputSchema,
+  entityIdSchema,
+} from "$lib/shared/domain";
+
+const listCommentsQuerySchema = z.object({
+  targetId: entityIdSchema,
+  targetType: commentTargetTypeSchema,
+});
+
+function jsonTimelineError(error: unknown) {
+  if (error instanceof TimelineRepositoryError) {
+    return json({ message: error.message }, { status: error.status });
+  }
+
+  console.error(error);
+  return json({ message: "Internal Server Error" }, { status: 500 });
+}
+
+export const GET: RequestHandler = async ({ url }) => {
+  const parsed = listCommentsQuerySchema.safeParse({
+    targetId: url.searchParams.get("targetId"),
+    targetType: url.searchParams.get("targetType"),
+  });
+
+  if (!parsed.success) {
+    return json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid query" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const comments = await listCommentsForTarget(
+      parsed.data.targetType,
+      parsed.data.targetId,
+    );
+
+    return json({
+      comments,
+    });
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+  if (!locals.user) {
+    return json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = createCommentInputSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid payload" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const comment = await createComment(locals.user.id, parsed.data);
+
+    return json(
+      {
+        comment,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -25,7 +25,7 @@ function jsonTimelineError(error: unknown) {
   return json({ message: "Internal Server Error" }, { status: 500 });
 }
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ locals, url }) => {
   const parsed = listCommentsQuerySchema.safeParse({
     targetId: url.searchParams.get("targetId"),
     targetType: url.searchParams.get("targetType"),
@@ -42,6 +42,7 @@ export const GET: RequestHandler = async ({ url }) => {
     const comments = await listCommentsForTarget(
       parsed.data.targetType,
       parsed.data.targetId,
+      locals.user?.id,
     );
 
     return json({

--- a/src/routes/api/reactions/+server.ts
+++ b/src/routes/api/reactions/+server.ts
@@ -1,0 +1,81 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import {
+  addReaction,
+  removeReaction,
+  TimelineRepositoryError,
+} from "$lib/server/repositories/timeline";
+import { toggleReactionInputSchema } from "$lib/shared/domain";
+
+function jsonTimelineError(error: unknown) {
+  if (error instanceof TimelineRepositoryError) {
+    return json({ message: error.message }, { status: error.status });
+  }
+
+  console.error(error);
+  return json({ message: "Internal Server Error" }, { status: 500 });
+}
+
+async function parseReactionRequestBody(request: Request) {
+  const body = await request.json().catch(() => null);
+  return toggleReactionInputSchema.safeParse(body);
+}
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+  if (!locals.user) {
+    return json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = await parseReactionRequestBody(request);
+
+  if (!parsed.success) {
+    return json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid payload" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const reactions = await addReaction(
+      locals.user.id,
+      parsed.data.targetType,
+      parsed.data.targetId,
+      parsed.data.kind,
+    );
+
+    return json({
+      reactions,
+    });
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};
+
+export const DELETE: RequestHandler = async ({ locals, request }) => {
+  if (!locals.user) {
+    return json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = await parseReactionRequestBody(request);
+
+  if (!parsed.success) {
+    return json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid payload" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const reactions = await removeReaction(
+      locals.user.id,
+      parsed.data.targetType,
+      parsed.data.targetId,
+      parsed.data.kind,
+    );
+
+    return json({
+      reactions,
+    });
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};

--- a/src/routes/api/timeline/+server.ts
+++ b/src/routes/api/timeline/+server.ts
@@ -1,0 +1,94 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import {
+  createTimelinePost,
+  listTimelinePosts,
+  TimelineRepositoryError,
+} from "$lib/server/repositories/timeline";
+import { createTimelinePostInputSchema } from "$lib/shared/domain";
+import { parseTimelineScope } from "$lib/shared/timeline";
+
+function jsonTimelineError(error: unknown) {
+  if (error instanceof TimelineRepositoryError) {
+    return json({ message: error.message }, { status: error.status });
+  }
+
+  console.error(error);
+  return json({ message: "Internal Server Error" }, { status: 500 });
+}
+
+function parseLimit(value: string | null) {
+  if (!value) {
+    return 20;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 100) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export const GET: RequestHandler = async ({ locals, url }) => {
+  const scope = parseTimelineScope(url.searchParams.get("scope"));
+  const limit = parseLimit(url.searchParams.get("limit"));
+
+  if (limit === null) {
+    return json(
+      { message: "limit は 1 以上 100 以下の整数で指定してください。" },
+      { status: 400 },
+    );
+  }
+
+  if (scope === "following" && !locals.user) {
+    return json(
+      { message: "フォロー中フィードの取得にはログインが必要です。" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const posts = await listTimelinePosts({
+      scope,
+      viewerUserId: locals.user?.id,
+      limit,
+    });
+
+    return json({
+      posts,
+      scope,
+    });
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+  if (!locals.user) {
+    return json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = createTimelinePostInputSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid payload" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const post = await createTimelinePost(locals.user.id, parsed.data);
+
+    return json(
+      {
+        post,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};

--- a/src/routes/api/timeline/[postId]/+server.ts
+++ b/src/routes/api/timeline/[postId]/+server.ts
@@ -1,0 +1,23 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import { getTimelinePostViewById } from "$lib/server/repositories/timeline";
+
+export const GET: RequestHandler = async ({ locals, params }) => {
+  const postId = params.postId;
+
+  if (!postId) {
+    return json({ message: "postId is required" }, { status: 400 });
+  }
+
+  const post = await getTimelinePostViewById(postId, locals.user?.id);
+
+  if (!post) {
+    return json(
+      { message: "タイムライン投稿が見つかりません。" },
+      { status: 404 },
+    );
+  }
+
+  return json({
+    post,
+  });
+};

--- a/src/routes/api/timeline/[postId]/solve/+server.ts
+++ b/src/routes/api/timeline/[postId]/solve/+server.ts
@@ -1,0 +1,51 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import {
+  solveTimelinePost,
+  TimelineRepositoryError,
+} from "$lib/server/repositories/timeline";
+import { solveTimelinePostInputSchema } from "$lib/shared/timeline";
+
+function jsonTimelineError(error: unknown) {
+  if (error instanceof TimelineRepositoryError) {
+    return json({ message: error.message }, { status: error.status });
+  }
+
+  console.error(error);
+  return json({ message: "Internal Server Error" }, { status: 500 });
+}
+
+export const POST: RequestHandler = async ({ locals, params, request }) => {
+  if (!locals.user) {
+    return json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const postId = params.postId;
+
+  if (!postId) {
+    return json({ message: "postId is required" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = solveTimelinePostInputSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid payload" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const post = await solveTimelinePost(
+      postId,
+      locals.user.id,
+      parsed.data.acceptedCommentId,
+    );
+
+    return json({
+      post,
+    });
+  } catch (error) {
+    return jsonTimelineError(error);
+  }
+};

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,77 +1,96 @@
 <script lang="ts">
+    import { page } from "$app/stores";
+    import { sessionUser } from "$lib/stores/session";
     import {
-        currentUser,
-        projects,
         supportRecords,
         messages,
-        timelinePosts,
         conversations,
-        userPreferences,
         users,
     } from "$lib/stores/mock";
     import ProjectCard from "$lib/components/projects/ProjectCard.svelte";
     import TimelinePostCard from "$lib/components/timeline/TimelinePostCard.svelte";
+    import type {
+        ProjectHelpType,
+        ProjectStage,
+        ProjectStatus,
+    } from "$lib/shared/domain";
+    import type { TimelinePostView } from "$lib/shared/timeline";
     import { Plus, Gift, MessageSquare, HelpCircle } from "lucide-svelte";
 
-    $: myProjects = $projects.filter((p) => p.ownerId === $currentUser?.id);
+    export let data: {
+        myProjects: Array<{
+            id: string;
+            ownerId: string;
+            ownerName: string | null;
+            ownerAvatarUrl: string | null;
+            title: string;
+            oneLiner: string;
+            problemStatement: string;
+            projectStage: ProjectStage | null;
+            helpTypes: ProjectHelpType[];
+            helpRequest: string;
+            highlights: string[];
+            nextMilestone: string;
+            feedbackRequest: string;
+            backgroundNote: string;
+            publicUrl?: string;
+            repoUrl?: string;
+            demoUrl?: string;
+            tags: string[];
+            images: string[];
+            status: ProjectStatus;
+            createdAt: string;
+            updatedAt: string;
+        }>;
+        myUnresolvedQuestions: TimelinePostView[];
+    };
 
-    // Support waiting for my confirmation
-    $: myProjectIds = myProjects.map((p) => p.id);
+    $: myProjectIds = data.myProjects.map((project) => project.id);
     $: pendingSupports = $supportRecords.filter(
-        (r) =>
-            myProjectIds.includes(r.projectId) && r.status === "awaiting_owner",
+        (record) =>
+            myProjectIds.includes(record.projectId) &&
+            record.status === "awaiting_owner",
     );
 
-    // Unresolved Questions
-    $: myUnresolvedQuestions = $timelinePosts.filter(
-        (p) =>
-            p.authorId === $currentUser?.id &&
-            p.type === "question" &&
-            p.status === "open",
-    );
-
-    // Unread Messages (Mock: Showing recent conversations)
     $: myConversations = $conversations
-        .filter((c) => c.memberIds.includes($currentUser?.id ?? ""))
+        .filter((conversation) =>
+            conversation.memberIds.includes($sessionUser?.id ?? ""),
+        )
         .sort(
             (a, b) =>
                 new Date(b.lastMessageAt).getTime() -
                 new Date(a.lastMessageAt).getTime(),
         );
 
-    // Focus Mode
-    $: myPreferences = $userPreferences.find(
-        (p) => p.userId === $currentUser?.id,
-    );
-    $: focusModes = myPreferences?.focusModes || [];
+    $: focusModes = $page.data.preferences?.focusModes ?? [];
 
-    // Helper to get conversation partner
     function getPartner(memberIds: string[]) {
-        const partnerId = memberIds.find((id) => id !== $currentUser?.id);
-        return $users.find((u) => u.id === partnerId);
+        const partnerId = memberIds.find((id) => id !== $sessionUser?.id);
+        return $users.find((user) => user.id === partnerId);
     }
 
     function getLastMessage(conversationId: string) {
-        const msgs = $messages.filter(
-            (m) => m.conversationId === conversationId,
+        const history = $messages.filter(
+            (message) => message.conversationId === conversationId,
         );
-        return msgs[msgs.length - 1];
+        return history[history.length - 1];
     }
 </script>
 
 <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
     <div class="flex items-center gap-4 mb-8">
         <img
-            src={$currentUser?.avatarUrl}
+            src={$sessionUser?.avatarUrl ||
+                `https://i.pravatar.cc/150?u=${encodeURIComponent($sessionUser?.id ?? "guest")}`}
             class="w-16 h-16 rounded-full border-2 border-white shadow"
             alt=""
         />
         <div>
             <h1 class="text-3xl font-bold text-gray-900">
-                {$currentUser?.name}のダッシュボード
+                {$sessionUser?.name ?? "User"}のダッシュボード
             </h1>
-            <p class="text-gray-500">{$currentUser?.email}</p>
-            <div class="flex gap-2 mt-2">
+            <p class="text-gray-500">{$sessionUser?.email}</p>
+            <div class="flex gap-2 mt-2 flex-wrap">
                 {#each focusModes as mode}
                     <span
                         class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 border border-gray-200"
@@ -84,10 +103,8 @@
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <!-- Main Column -->
         <div class="lg:col-span-2 space-y-8">
-            <!-- Unresolved Questions -->
-            {#if myUnresolvedQuestions.length > 0}
+            {#if data.myUnresolvedQuestions.length > 0}
                 <section>
                     <div class="flex items-center justify-between mb-4">
                         <h2
@@ -98,18 +115,17 @@
                         </h2>
                     </div>
                     <div class="space-y-4">
-                        {#each myUnresolvedQuestions as post}
+                        {#each data.myUnresolvedQuestions as post (post.id)}
                             <TimelinePostCard {post} compact />
                         {/each}
                     </div>
                 </section>
             {/if}
 
-            <!-- Projects -->
             <section>
                 <div class="flex items-center justify-between mb-4">
                     <h2 class="text-xl font-bold text-gray-900">
-                        自分のプロジェクト ({myProjects.length})
+                        自分のプロジェクト ({data.myProjects.length})
                     </h2>
                     <a
                         href="/projects/new"
@@ -120,10 +136,10 @@
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {#each myProjects as project}
+                    {#each data.myProjects as project (project.id)}
                         <ProjectCard {project} />
                     {/each}
-                    {#if myProjects.length === 0}
+                    {#if data.myProjects.length === 0}
                         <div
                             class="col-span-full py-8 text-center bg-gray-50 rounded-xl border border-dashed border-gray-300 text-gray-500"
                         >
@@ -134,9 +150,7 @@
             </section>
         </div>
 
-        <!-- Sidebar -->
         <div class="space-y-6">
-            <!-- Support Pending -->
             <div
                 class="bg-white rounded-xl shadow-sm border border-orange-200 overflow-hidden"
             >
@@ -162,7 +176,7 @@
                                         ¥{support.amount.toLocaleString()}
                                     </div>
                                     <a
-                                        href="/projects/{support.projectId}"
+                                        href={`/projects/${support.projectId}`}
                                         class="text-indigo-600 hover:underline text-xs"
                                         >確認画面へ</a
                                     >
@@ -177,7 +191,6 @@
                 </div>
             </div>
 
-            <!-- Messages -->
             <div
                 class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden"
             >
@@ -191,9 +204,9 @@
                 <div class="divide-y divide-gray-100">
                     {#each myConversations as conversation}
                         {@const partner = getPartner(conversation.memberIds)}
-                        {@const lastMsg = getLastMessage(conversation.id)}
+                        {@const lastMessage = getLastMessage(conversation.id)}
                         <a
-                            href="/messages/{conversation.id}"
+                            href={`/messages/${conversation.id}`}
                             class="block p-3 hover:bg-gray-50 transition-colors"
                         >
                             <div class="flex items-center gap-3">
@@ -230,8 +243,8 @@
                                         </div>
                                     </div>
                                     <div class="text-sm text-gray-500 truncate">
-                                        {lastMsg
-                                            ? lastMsg.body
+                                        {lastMessage
+                                            ? lastMessage.body
                                             : "まだメッセージはありません"}
                                     </div>
                                 </div>

--- a/src/routes/projects/[id]/+page.server.ts
+++ b/src/routes/projects/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import {
   getProjectById,
   getProjectViewById,
 } from "$lib/server/repositories/projects";
+import { listReactionSummaryForTarget } from "$lib/server/repositories/timeline";
 import {
   isProjectSuccessToast,
   type ProjectSuccessToast,
@@ -23,7 +24,10 @@ export const load: PageServerLoad = async ({ locals, params, url }) => {
     throw error(404, "プロジェクトが見つかりません。");
   }
 
-  const project = await getProjectViewById(params.id);
+  const [project, projectReactions] = await Promise.all([
+    getProjectViewById(params.id),
+    listReactionSummaryForTarget("project", params.id, locals.user?.id),
+  ]);
 
   if (!project) {
     throw error(404, "プロジェクトが見つかりません。");
@@ -39,6 +43,7 @@ export const load: PageServerLoad = async ({ locals, params, url }) => {
   return {
     canEdit: rawProject.ownerUserId === locals.user?.id,
     project,
+    projectReactions,
     successToast,
   };
 };

--- a/src/routes/projects/[id]/+page.svelte
+++ b/src/routes/projects/[id]/+page.svelte
@@ -18,6 +18,7 @@
         getProjectSuccessToastMessage,
         type ProjectSuccessToast,
     } from "$lib/shared/project-form";
+    import type { TimelineReactionSummary } from "$lib/shared/timeline";
     import {
         Github,
         Globe,
@@ -34,6 +35,7 @@
 
     export let data: {
         canEdit: boolean;
+        projectReactions: TimelineReactionSummary[];
         successToast: ProjectSuccessToast | null;
         project: {
             id: string;
@@ -291,7 +293,11 @@
         </div>
 
         <div class="mt-6">
-            <ReactionBar targetId={project.id} targetType="project" />
+            <ReactionBar
+                targetId={project.id}
+                targetType="project"
+                reactions={data.projectReactions}
+            />
         </div>
 
         {#if showOwnerChecklist}

--- a/src/routes/timeline/+page.server.ts
+++ b/src/routes/timeline/+page.server.ts
@@ -1,0 +1,35 @@
+import type { PageServerLoad } from "./$types";
+import { listProjects } from "$lib/server/repositories/projects";
+import { listTimelinePosts } from "$lib/server/repositories/timeline";
+import {
+  parseTimelineScope,
+  TIMELINE_INVALIDATION_KEY,
+} from "$lib/shared/timeline";
+
+export const load: PageServerLoad = async (event) => {
+  event.depends(TIMELINE_INVALIDATION_KEY);
+
+  const scope = parseTimelineScope(event.url.searchParams.get("scope"));
+  const [posts, myProjects] = await Promise.all([
+    scope === "following" && !event.locals.user
+      ? Promise.resolve([])
+      : listTimelinePosts({
+          scope,
+          viewerUserId: event.locals.user?.id,
+          limit: 20,
+        }),
+    event.locals.user
+      ? listProjects({
+          ownerUserId: event.locals.user.id,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    scope,
+    posts,
+    myProjects,
+    canViewFollowing: Boolean(event.locals.user),
+    isLoggedIn: Boolean(event.locals.user),
+  };
+};

--- a/src/routes/timeline/+page.server.ts
+++ b/src/routes/timeline/+page.server.ts
@@ -21,6 +21,7 @@ export const load: PageServerLoad = async (event) => {
     event.locals.user
       ? listProjects({
           ownerUserId: event.locals.user.id,
+          statuses: ["published"],
         })
       : Promise.resolve([]),
   ]);

--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -1,59 +1,85 @@
 <script lang="ts">
-    import { timelinePosts } from "$lib/stores/mock";
     import TimelineComposer from "$lib/components/timeline/TimelineComposer.svelte";
     import TimelinePostCard from "$lib/components/timeline/TimelinePostCard.svelte";
+    import type { TimelinePostView, TimelineScope } from "$lib/shared/timeline";
 
-    // Sort by createdAt desc
-    $: posts = $timelinePosts.sort(
-        (a, b) =>
-            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
-
-    let activeTab = "all"; // all, following, project
+    export let data: {
+        scope: TimelineScope;
+        posts: TimelinePostView[];
+        myProjects: Array<{
+            id: string;
+            title: string;
+        }>;
+        canViewFollowing: boolean;
+        isLoggedIn: boolean;
+    };
 </script>
 
 <div class="flex gap-8">
-    <!-- Left Column: Main Feed -->
     <div class="flex-1 max-w-2xl">
         <div class="mb-6 flex items-center justify-between">
             <h1 class="text-2xl font-bold">タイムライン</h1>
 
-            <!-- Filter Tabs (Visual Only for MVP) -->
             <div class="flex bg-gray-100 p-1 rounded-lg">
-                <button
-                    class="px-3 py-1 text-sm font-medium rounded {activeTab ===
-                    'all'
-                        ? 'bg-white shadow'
-                        : 'text-gray-500'}"
-                    on:click={() => (activeTab = "all")}>全体</button
+                <a
+                    href="/timeline?scope=global"
+                    class={`px-3 py-1 text-sm font-medium rounded ${
+                        data.scope === "global"
+                            ? "bg-white shadow"
+                            : "text-gray-500"
+                    }`}
                 >
-                <button
-                    class="px-3 py-1 text-sm font-medium rounded {activeTab ===
-                    'following'
-                        ? 'bg-white shadow'
-                        : 'text-gray-500'}"
-                    on:click={() => (activeTab = "following")}
-                    >フォロー中</button
+                    全体
+                </a>
+                <a
+                    href="/timeline?scope=following"
+                    class={`px-3 py-1 text-sm font-medium rounded ${
+                        data.scope === "following"
+                            ? "bg-white shadow"
+                            : "text-gray-500"
+                    }`}
                 >
+                    フォロー中
+                </a>
             </div>
         </div>
 
-        <TimelineComposer />
+        <TimelineComposer projects={data.myProjects} />
 
-        {#each posts as post (post.id)}
-            <TimelinePostCard {post} />
-        {/each}
-
-        {#if posts.length === 0}
-            <div class="text-center py-12 text-gray-500">
+        {#if data.scope === "following" && !data.canViewFollowing}
+            <div
+                class="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center"
+            >
+                <p class="text-sm text-gray-600">
+                    フォロー中フィードを見るにはログインが必要です。
+                </p>
+                <a
+                    href="/login?next=%2Ftimeline%3Fscope%3Dfollowing"
+                    class="mt-4 inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                >
+                    ログインする
+                </a>
+            </div>
+        {:else if data.posts.length > 0}
+            {#each data.posts as post (post.id)}
+                <TimelinePostCard {post} />
+            {/each}
+        {:else if data.scope === "following"}
+            <div
+                class="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center text-gray-500"
+            >
+                まだフォロー中の投稿がありません。
+            </div>
+        {:else}
+            <div
+                class="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center text-gray-500"
+            >
                 投稿がありません。最初の投稿をしてみましょう！
             </div>
         {/if}
     </div>
 
-    <!-- Right Column: Sidebar (Mock) -->
     <div class="hidden lg:block w-80 space-y-6">
-        <!-- Active Events -->
         <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
             <h3 class="font-bold text-gray-900 mb-3">開催中のイベント</h3>
             <div class="text-sm text-gray-500">
@@ -61,10 +87,8 @@
             </div>
         </div>
 
-        <!-- Recommended Users -->
         <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
             <h3 class="font-bold text-gray-900 mb-3">おすすめユーザー</h3>
-            <!-- Mock list -->
             <div class="space-y-3">
                 <div class="flex items-center gap-2">
                     <div class="w-8 h-8 rounded-full bg-indigo-100"></div>

--- a/src/routes/timeline/[id]/+page.server.ts
+++ b/src/routes/timeline/[id]/+page.server.ts
@@ -1,0 +1,21 @@
+import { error } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
+import { getTimelinePostViewById } from "$lib/server/repositories/timeline";
+import { TIMELINE_INVALIDATION_KEY } from "$lib/shared/timeline";
+
+export const load: PageServerLoad = async (event) => {
+  event.depends(TIMELINE_INVALIDATION_KEY);
+
+  const post = await getTimelinePostViewById(
+    event.params.id,
+    event.locals.user?.id,
+  );
+
+  if (!post) {
+    throw error(404, "タイムライン投稿が見つかりません。");
+  }
+
+  return {
+    post,
+  };
+};

--- a/src/routes/timeline/[id]/+page.svelte
+++ b/src/routes/timeline/[id]/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import TimelinePostCard from "$lib/components/timeline/TimelinePostCard.svelte";
+    import type { TimelinePostView } from "$lib/shared/timeline";
+    import { ArrowLeft } from "lucide-svelte";
+
+    export let data: {
+        post: TimelinePostView;
+    };
+</script>
+
+<div class="mx-auto max-w-3xl space-y-6">
+    <a
+        href="/timeline"
+        class="inline-flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-500"
+    >
+        <ArrowLeft class="h-4 w-4" />
+        タイムラインに戻る
+    </a>
+
+    <div>
+        <TimelinePostCard
+            post={data.post}
+            showDetailLink={false}
+            showAllComments={true}
+        />
+    </div>
+</div>

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -1,0 +1,78 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { PageServerLoad } from "./$types";
+import { getUserPreferencesState } from "$lib/server/account-settings";
+import { getDb } from "$lib/server/db";
+import { supportRecords, users } from "$lib/server/db/schema";
+import { listProjects } from "$lib/server/repositories/projects";
+import { listTimelinePosts } from "$lib/server/repositories/timeline";
+import { TIMELINE_INVALIDATION_KEY } from "$lib/shared/timeline";
+
+export const load: PageServerLoad = async (event) => {
+  event.depends(TIMELINE_INVALIDATION_KEY);
+
+  const userId = event.params.id;
+  const db = getDb();
+  const [profileRecord] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.displayName,
+      avatarUrl: users.avatarUrl,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!profileRecord) {
+    return {
+      profile: null,
+      userProjects: [],
+      recentPosts: [],
+      focusModes: [],
+      totalConfirmedSupport: 0,
+    };
+  }
+
+  const isOwnProfile = event.locals.user?.id === userId;
+  const [preferences, userProjects, recentPosts] = await Promise.all([
+    getUserPreferencesState(userId),
+    listProjects({
+      ownerUserId: userId,
+      statuses: isOwnProfile ? undefined : ["published"],
+    }),
+    listTimelinePosts({
+      authorUserId: userId,
+      viewerUserId: event.locals.user?.id,
+      limit: 5,
+    }),
+  ]);
+
+  const projectIds = userProjects.map((project) => project.id);
+  const confirmedSupportRows =
+    projectIds.length > 0
+      ? await db
+          .select({
+            amountJpy: supportRecords.amountJpy,
+          })
+          .from(supportRecords)
+          .where(
+            and(
+              inArray(supportRecords.projectId, projectIds),
+              eq(supportRecords.status, "confirmed"),
+            ),
+          )
+      : [];
+
+  const totalConfirmedSupport = confirmedSupportRows.reduce(
+    (sum, record) => sum + record.amountJpy,
+    0,
+  );
+
+  return {
+    profile: profileRecord,
+    userProjects,
+    recentPosts,
+    focusModes: preferences.focusModes,
+    totalConfirmedSupport,
+  };
+};

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async (event) => {
   event.depends(TIMELINE_INVALIDATION_KEY);
 
   const userId = event.params.id;
+  const isOwnProfile = event.locals.user?.id === userId;
   const db = getDb();
   const [profileRecord] = await db
     .select({
@@ -33,7 +34,6 @@ export const load: PageServerLoad = async (event) => {
     };
   }
 
-  const isOwnProfile = event.locals.user?.id === userId;
   const [preferences, userProjects, recentPosts] = await Promise.all([
     getUserPreferencesState(userId),
     listProjects({
@@ -69,7 +69,10 @@ export const load: PageServerLoad = async (event) => {
   );
 
   return {
-    profile: profileRecord,
+    profile: {
+      ...profileRecord,
+      email: isOwnProfile ? profileRecord.email : null,
+    },
     userProjects,
     recentPosts,
     focusModes: preferences.focusModes,

--- a/src/routes/users/[id]/+page.svelte
+++ b/src/routes/users/[id]/+page.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-    import { page } from "$app/stores";
-    import {
-        users,
-        projects,
-        timelinePosts,
-        supportRecords,
-        userPreferences,
-    } from "$lib/stores/mock";
+    import type {
+        ProjectHelpType,
+        ProjectStage,
+        ProjectStatus,
+    } from "$lib/shared/domain";
+    import type { FocusMode } from "$lib/shared/settings";
+    import type { TimelinePostView } from "$lib/shared/timeline";
     import { FolderKanban, Rocket, Gift, Calendar } from "lucide-svelte";
 
     function formatDateTime(value: string) {
@@ -25,50 +24,60 @@
         showcase: "見せびらかし",
     };
 
-    $: userId = $page.params.id ?? "";
-    $: profile = $users.find((user) => user.id === userId);
-    $: userProjects = [...$projects]
-        .filter((project) => project.ownerId === userId)
-        .sort(
-            (a, b) =>
-                new Date(b.updatedAt).getTime() -
-                new Date(a.updatedAt).getTime(),
-        );
-    $: recentPosts = [...$timelinePosts]
-        .filter((post) => post.authorId === userId)
-        .sort(
-            (a, b) =>
-                new Date(b.createdAt).getTime() -
-                new Date(a.createdAt).getTime(),
-        )
-        .slice(0, 5);
-    $: focusModes =
-        $userPreferences.find((pref) => pref.userId === userId)?.focusModes ?? [];
-
-    $: projectIds = userProjects.map((project) => project.id);
-    $: totalConfirmedSupport = $supportRecords
-        .filter(
-            (record) =>
-                projectIds.includes(record.projectId) &&
-                record.status === "confirmed",
-        )
-        .reduce((sum, record) => sum + record.amount, 0);
+    export let data: {
+        profile: {
+            id: string;
+            email: string;
+            name: string;
+            avatarUrl: string | null;
+        } | null;
+        userProjects: Array<{
+            id: string;
+            ownerId: string;
+            ownerName: string | null;
+            ownerAvatarUrl: string | null;
+            title: string;
+            oneLiner: string;
+            problemStatement: string;
+            projectStage: ProjectStage | null;
+            helpTypes: ProjectHelpType[];
+            helpRequest: string;
+            highlights: string[];
+            nextMilestone: string;
+            feedbackRequest: string;
+            backgroundNote: string;
+            publicUrl?: string;
+            repoUrl?: string;
+            demoUrl?: string;
+            tags: string[];
+            images: string[];
+            status: ProjectStatus;
+            createdAt: string;
+            updatedAt: string;
+        }>;
+        recentPosts: TimelinePostView[];
+        focusModes: FocusMode[];
+        totalConfirmedSupport: number;
+    };
 </script>
 
-{#if profile}
+{#if data.profile}
     <div class="max-w-5xl mx-auto py-8 space-y-8">
         <section class="bg-white rounded-xl border border-gray-200 p-6">
             <div class="flex flex-col md:flex-row md:items-center gap-5">
                 <img
-                    src={profile.avatarUrl}
+                    src={data.profile.avatarUrl ||
+                        `https://i.pravatar.cc/150?u=${encodeURIComponent(data.profile.id)}`}
                     alt=""
                     class="w-20 h-20 rounded-full border border-gray-200"
                 />
                 <div class="flex-1">
-                    <h1 class="text-3xl font-bold text-gray-900">{profile.name}</h1>
-                    <p class="text-sm text-gray-500 mt-1">{profile.email}</p>
+                    <h1 class="text-3xl font-bold text-gray-900">
+                        {data.profile.name}
+                    </h1>
+                    <p class="text-sm text-gray-500 mt-1">{data.profile.email}</p>
                     <div class="flex flex-wrap gap-2 mt-3">
-                        {#each focusModes as mode}
+                        {#each data.focusModes as mode}
                             <span
                                 class="px-2.5 py-1 rounded-full text-xs bg-indigo-50 text-indigo-700 border border-indigo-100"
                             >
@@ -80,13 +89,13 @@
                 <div class="grid grid-cols-2 gap-3 text-center">
                     <div class="rounded-lg bg-gray-50 px-4 py-3 min-w-[120px]">
                         <div class="text-xl font-black text-gray-900">
-                            {userProjects.length}
+                            {data.userProjects.length}
                         </div>
                         <div class="text-xs text-gray-500">Projects</div>
                     </div>
                     <div class="rounded-lg bg-gray-50 px-4 py-3 min-w-[120px]">
                         <div class="text-xl font-black text-gray-900">
-                            ¥{totalConfirmedSupport.toLocaleString()}
+                            ¥{data.totalConfirmedSupport.toLocaleString()}
                         </div>
                         <div class="text-xs text-gray-500">Confirmed Support</div>
                     </div>
@@ -100,7 +109,7 @@
                 プロジェクト
             </h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {#each userProjects as project}
+                {#each data.userProjects as project}
                     <a
                         href="/projects/{project.id}"
                         class="rounded-lg border border-gray-200 p-4 hover:bg-gray-50 transition-colors"
@@ -112,7 +121,7 @@
                             </span>
                         </div>
                         <p class="text-sm text-gray-600 mb-3 line-clamp-2">
-                            {project.summary}
+                            {project.oneLiner}
                         </p>
                         <div class="text-xs text-gray-400">
                             更新: {formatDateTime(project.updatedAt)}
@@ -120,8 +129,10 @@
                     </a>
                 {/each}
             </div>
-            {#if userProjects.length === 0}
-                <p class="text-sm text-gray-500">公開中のプロジェクトはありません。</p>
+            {#if data.userProjects.length === 0}
+                <p class="text-sm text-gray-500">
+                    表示できるプロジェクトはありません。
+                </p>
             {/if}
         </section>
 
@@ -131,7 +142,7 @@
                 最近の投稿
             </h2>
             <div class="space-y-3">
-                {#each recentPosts as post}
+                {#each data.recentPosts as post}
                     <article class="rounded-lg border border-gray-100 p-4 bg-gray-50/70">
                         <div class="flex items-center justify-between mb-2">
                             <span class="text-xs font-semibold text-indigo-600">
@@ -149,7 +160,7 @@
                     </article>
                 {/each}
             </div>
-            {#if recentPosts.length === 0}
+            {#if data.recentPosts.length === 0}
                 <p class="text-sm text-gray-500">投稿はまだありません。</p>
             {/if}
         </section>

--- a/src/routes/users/[id]/+page.svelte
+++ b/src/routes/users/[id]/+page.svelte
@@ -27,7 +27,7 @@
     export let data: {
         profile: {
             id: string;
-            email: string;
+            email: string | null;
             name: string;
             avatarUrl: string | null;
         } | null;
@@ -75,7 +75,11 @@
                     <h1 class="text-3xl font-bold text-gray-900">
                         {data.profile.name}
                     </h1>
-                    <p class="text-sm text-gray-500 mt-1">{data.profile.email}</p>
+                    {#if data.profile.email}
+                        <p class="text-sm text-gray-500 mt-1">
+                            {data.profile.email}
+                        </p>
+                    {/if}
                     <div class="flex flex-wrap gap-2 mt-3">
                         {#each data.focusModes as mode}
                             <span


### PR DESCRIPTION
## 概要
- タイムライン投稿・コメント・リアクションを DB 実データに切り替え
- `/timeline/[id]` の詳細ページを追加
- ホーム / タイムライン / ダッシュボード / プロフィールの関連セクションを同じデータソースに統一
- レビュー対応として、公開プロフィールのメール非表示と archived プロジェクトの可視性整合を反映

## 実装したユーザーストーリー
- ユーザーとして、進捗 / 相談 / 見せびらかし投稿を作成し、リロード後もホームやタイムラインで確認したい
- ユーザーとして、相談投稿に状況・困りごと・試したこと・環境を添えて投稿し、ベスト回答を選んで解決済みにしたい
- ユーザーとして、タイムライン投稿やプロジェクトにコメント / 5種類のリアクションで反応したい
- ユーザーとして、ホーム / タイムライン / 投稿詳細 / ダッシュボード / プロフィールで同じ実データを参照したい

## 変更点
- timeline repository と shared timeline view model を追加
- `/api/timeline`、`/api/comments`、`/api/reactions`、`/api/timeline/:id`、`/api/timeline/:id/solve` を実装
- `TimelineComposer` / `TimelinePostCard` / `CommentSection` / `ReactionBar` を `fetch + invalidate` に変更
- `/`、`/timeline`、`/timeline/[id]`、`/dashboard`、`/users/[id]` を server load 化
- プロジェクト詳細のリアクション表示も実データ化
- 公開プロフィールでは本人以外のメールアドレスを返さないよう修正
- archived プロジェクトのタイムライン上の可視性をプロジェクト詳細ルートと整合させた

## 動作確認
- `pnpm check`
- `pnpm exec vitest run src/lib/server/repositories/timeline.test.ts`

Closes #7
