### PR TITLE
fix: Vercelビルド回避策をmain向けに整理

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "growth-hach",
   "private": true,
   "version": "0.0.1",
+  "packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4",
   "type": "module",
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "build": "vite build",
+    "vercel:build": "node scripts/vercel-build.mjs",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -75,7 +75,7 @@ function patchNft() {
   const emitDependencyReplacement = `async emitDependency(path, parent, depth = this.depth) {\n        const ignoreSandboxDependency = parent === '/var/task/sandbox.js';\n        if (ignoreSandboxDependency)\n            return;\n        if (depth < 0)\n            throw new Error('invariant - depth option cannot be negative');`;
 
   const missingFilePattern =
-    /if \(source === null\) \{[\s\S]*?throw new Error\('File ' \+ realPath \+ ' does not exist\.'\);\n\s*\}/;
+    /if \(source === null\)\s*(?:\{\s*)?throw new Error\('File ' \+ realPath \+ ' does not exist\.'\);\s*(?:\})?/;
   const missingFileReplacement = `if (source === null) {\n                const ignoreMissingFile = realPath.includes('/.local/share/pnpm/.tools/pnpm/') || realPath.includes('/.pnpm-store/') || realPath.includes('/usr/bin') || realPath.includes('/proc/') || path.includes('/.local/share/pnpm/.tools/pnpm/') || path.includes('/vercel/.local/share/pnpm/') || path.includes('/.pnpm-store/') || path.includes('/usr/bin') || path.includes('/proc/') || parent === '/var/task/sandbox.js';\n                if (ignoreMissingFile) {\n                    return;\n                }\n                throw new Error('File ' + realPath + ' does not exist.');\n            }`;
 
   let nextSource = regexReplace(

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+// Vercel build で adapter-vercel / @vercel/nft が sandbox.js と pnpm 一時パスを
+// 誤って runtime dependency として追うため、build 中だけ最小パッチを当てる。
+const workspaceRoot = process.cwd();
+const dryRun = process.argv.includes("--dry-run");
+const verbose = dryRun || process.env.VERCEL_BUILD_PATCH_VERBOSE === "1";
+const workspaceRequire = createRequire(path.join(workspaceRoot, "package.json"));
+const adapterPackageJsonPath = workspaceRequire.resolve("@sveltejs/adapter-vercel/package.json");
+const adapterIndexPath = path.join(path.dirname(adapterPackageJsonPath), "index.js");
+const adapterRequire = createRequire(adapterPackageJsonPath);
+
+const pnpmTemporaryPathPatterns = [
+  "/.local/share/pnpm/.tools/pnpm/",
+  `${path.sep}.tools${path.sep}pnpm${path.sep}`,
+];
+
+function log(label, value) {
+  if (!verbose || value === undefined) {
+    return;
+  }
+
+  console.error(`[vercel-build] ${label}: ${value}`);
+}
+
+function hasAnyPattern(value, patterns) {
+  if (!value) {
+    return false;
+  }
+
+  return patterns.some((pattern) => value.includes(pattern));
+}
+
+function exactReplace(source, original, replacement, errorMessage) {
+  if (source.includes(original)) {
+    return source.replace(original, replacement);
+  }
+
+  if (source.includes(replacement)) {
+    return source;
+  }
+
+  throw new Error(errorMessage);
+}
+
+function regexReplace(source, pattern, replacement, errorMessage) {
+  if (pattern.test(source)) {
+    return source.replace(pattern, replacement);
+  }
+
+  if (source.includes(replacement)) {
+    return source;
+  }
+
+  throw new Error(errorMessage);
+}
+
+function resolveNftPath() {
+  try {
+    return workspaceRequire.resolve("@vercel/nft/out/node-file-trace.js");
+  } catch {
+    return adapterRequire.resolve("@vercel/nft/out/node-file-trace.js");
+  }
+}
+
+function patchNft() {
+  const nftPath = resolveNftPath();
+  const source = fs.readFileSync(nftPath, "utf8");
+
+  const emitDependencyPattern =
+    /async emitDependency\(path, parent, depth = this\.depth\) \{\n(?:        const ignoreSandboxDependency = [^\n]+\n        if \(ignoreSandboxDependency\)\n            return;\n)?        if \(depth < 0\)\n            throw new Error\('invariant - depth option cannot be negative'\);/;
+  const emitDependencyReplacement = `async emitDependency(path, parent, depth = this.depth) {\n        const ignoreSandboxDependency = parent === '/var/task/sandbox.js';\n        if (ignoreSandboxDependency)\n            return;\n        if (depth < 0)\n            throw new Error('invariant - depth option cannot be negative');`;
+
+  const missingFilePattern =
+    /if \(source === null\) \{[\s\S]*?throw new Error\('File ' \+ realPath \+ ' does not exist\.'\);\n\s*\}/;
+  const missingFileReplacement = `if (source === null) {\n                const ignoreMissingFile = realPath.includes('/.local/share/pnpm/.tools/pnpm/') || realPath.includes('/.pnpm-store/') || realPath.includes('/usr/bin') || realPath.includes('/proc/') || path.includes('/.local/share/pnpm/.tools/pnpm/') || path.includes('/vercel/.local/share/pnpm/') || path.includes('/.pnpm-store/') || path.includes('/usr/bin') || path.includes('/proc/') || parent === '/var/task/sandbox.js';\n                if (ignoreMissingFile) {\n                    return;\n                }\n                throw new Error('File ' + realPath + ' does not exist.');\n            }`;
+
+  let nextSource = regexReplace(
+    source,
+    emitDependencyPattern,
+    emitDependencyReplacement,
+    `@vercel/nft の emitDependency パッチ対象が見つかりません: ${nftPath}`,
+  );
+
+  nextSource = regexReplace(
+    nextSource,
+    missingFilePattern,
+    missingFileReplacement,
+    `@vercel/nft の missing-file パッチ対象が見つかりません: ${nftPath}`,
+  );
+
+  if (nextSource !== source) {
+    fs.writeFileSync(nftPath, nextSource);
+  }
+
+  log("patched nft", nftPath);
+}
+
+function patchAdapter() {
+  const source = fs.readFileSync(adapterIndexPath, "utf8");
+
+  const originalTraceLine = `\tconst traced = await nodeFileTrace([entry], { base });`;
+  const patchedTraceLine = `\tconst traced = await nodeFileTrace([entry], {\n\t\tbase,\n\t\tignore: (value) =>\n\t\t\tvalue.includes('.pnpm-store/') ||\n\t\t\tvalue.includes('.local/share/pnpm/') ||\n\t\t\tvalue.includes('/proc/') ||\n\t\t\tvalue.includes('/usr/bin') ||\n\t\t\tvalue.includes('var/task/sandbox.js')\n\t});`;
+
+  const originalWarningBlock = `\tif (resolution_failures.size > 0) {\n\t\tconst cwd = process.cwd();\n\t\tbuilder.log.warn(\n\t\t\t'Warning: The following modules failed to locate dependencies that may (or may not) be required for your app to work:'\n\t\t);\n\n\t\tfor (const [importer, modules] of resolution_failures) {\n\t\t\tconsole.error(\`  \${path.relative(cwd, importer)}\`);\n\t\t\tfor (const module of modules) {\n\t\t\t\tconsole.error(\`    - \\u001B[1m\\u001B[36m\${module}\\u001B[39m\\u001B[22m\`);\n\t\t\t}\n\t\t}\n\t}`;
+  const patchedWarningBlock = `\tconst noisy_warning_patterns = [\n\t\t'/var/task/sandbox.js',\n\t\t'/.pnpm-store/',\n\t\t'/vercel/.local/share/pnpm/',\n\t\t'/.local/share/pnpm/',\n\t\t'/.vercel/output/functions/',\n\t\t'/usr/bin',\n\t\t'/proc/'\n\t];\n\tconst is_noisy_warning = (value) => noisy_warning_patterns.some((pattern) => value.includes(pattern));\n\tconst filtered_resolution_failures = new Map();\n\n\t\tfor (const [importer, modules] of resolution_failures) {\n\t\t\tif (is_noisy_warning(importer)) continue;\n\t\t\tconst filtered_modules = modules.filter((module) => !is_noisy_warning(module)).slice(0, 20);\n\t\t\tif (filtered_modules.length === 0) continue;\n\t\t\tfiltered_resolution_failures.set(importer, filtered_modules);\n\t\t}\n\n\tif (filtered_resolution_failures.size > 0) {\n\t\tconst cwd = process.cwd();\n\t\tbuilder.log.warn(\n\t\t\t'Warning: The following modules failed to locate dependencies that may (or may not) be required for your app to work:'\n\t\t);\n\n\t\tfor (const [importer, modules] of filtered_resolution_failures) {\n\t\t\tconsole.error(\`  \${path.relative(cwd, importer)}\`);\n\t\t\tfor (const module of modules) {\n\t\t\t\tconsole.error(\`    - \\u001B[1m\\u001B[36m\${module}\\u001B[39m\\u001B[22m\`);\n\t\t\t}\n\t\t}\n\t}`;
+
+  let nextSource = exactReplace(
+    source,
+    originalTraceLine,
+    patchedTraceLine,
+    `@sveltejs/adapter-vercel の trace パッチ対象が見つかりません: ${adapterIndexPath}`,
+  );
+
+  nextSource = exactReplace(
+    nextSource,
+    originalWarningBlock,
+    patchedWarningBlock,
+    `@sveltejs/adapter-vercel の warning パッチ対象が見つかりません: ${adapterIndexPath}`,
+  );
+
+  if (nextSource !== source) {
+    fs.writeFileSync(adapterIndexPath, nextSource);
+  }
+
+  log("patched adapter", adapterIndexPath);
+}
+
+function createBuildEnvironment() {
+  const env = { ...process.env };
+  const pathEntries = (env.PATH ?? "").split(path.delimiter);
+  env.PATH = pathEntries
+    .filter((entry) => entry && !hasAnyPattern(entry, pnpmTemporaryPathPatterns))
+    .join(path.delimiter);
+
+  for (const key of ["npm_execpath", "npm_config_user_agent", "npm_config_node_gyp", "NODE_PATH"]) {
+    delete env[key];
+  }
+
+  return env;
+}
+
+async function runBuild() {
+  const child = spawn(process.execPath, ["./node_modules/vite/bin/vite.js", "build"], {
+    cwd: workspaceRoot,
+    env: createBuildEnvironment(),
+    stdio: "inherit",
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`build が signal ${signal} で終了しました`));
+        return;
+      }
+
+      resolve(code ?? 1);
+    });
+  });
+
+  process.exit(exitCode);
+}
+
+patchNft();
+patchAdapter();
+
+if (dryRun) {
+  log("mode", "dry-run");
+  process.exit(0);
+}
+
+await runBuild();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "node scripts/vercel-build.mjs"
+}


### PR DESCRIPTION
## 概要
- Vercel 本番ビルドで発生していた `sandbox.js` / pnpm store 起点の偽依存トレースを回避
- `vercel.json` から専用 build script を使うようにして、`main` へ取り込みやすい最小構成に整理
- `packageManager` を固定して Vercel 側の pnpm 解決差分を減らす

## 変更内容
- `package.json`
  - `packageManager` を固定
  - `vercel:build` script を追加
- `vercel.json`
  - Vercel の `buildCommand` を `node scripts/vercel-build.mjs` に設定
- `scripts/vercel-build.mjs`
  - `@vercel/nft` と `@sveltejs/adapter-vercel` に build 時だけ最小パッチを適用
  - `/var/task/sandbox.js`、`/proc`、`/usr/bin`、pnpm の一時パスと store を trace しないよう制御
  - noisy な warning を抑制

## 確認
- `pnpm check`
- `pnpm run vercel:build`
- Vercel 上で `codex/main-vercel-build` のデプロイ成功を確認

Closes #19
